### PR TITLE
DEP: The implementation of Fourier Motzkin Elimination algorithm (no longer continued)

### DIFF
--- a/include/klee/Solver.h
+++ b/include/klee/Solver.h
@@ -233,7 +233,7 @@ namespace klee {
   #endif /*SUPPORT_STP */
 
 #ifdef SUPPORT_Z3
-/// Z3Solver - A complete solver based on Z3
+  /// Z3Solver - A complete solver based on Z3
   class Z3Solver : public Solver {
   public:
 	/// Z3Solver - Construct a new Z3Solver.

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -147,6 +147,13 @@ SubsumptionTableEntry::hasExistentials(std::vector<const Array *> &existentials,
   return false;
 }
 
+ref<Expr>
+SubsumptionTableEntry::simplifyWithFourierMotzkin(ref<Expr> existsExpr) {
+  // This is a template for Fourier-Motzkin elimination. For now,
+  // we simply return the input argument.
+  return existsExpr;
+}
+
 ref<Expr> SubsumptionTableEntry::simplifyArithmeticBody(ref<Expr> existsExpr) {
   assert(llvm::isa<ExistsExpr>(existsExpr));
 
@@ -281,7 +288,7 @@ ref<Expr> SubsumptionTableEntry::simplifyArithmeticBody(ref<Expr> existsExpr) {
     newBody = AndExpr::alloc(simplifiedInterpolant, fullEqualityConstraint);
   }
 
-  return existsExpr->rebuild(&newBody);
+  return simplifyWithFourierMotzkin(existsExpr->rebuild(&newBody));
 }
 
 ref<Expr> SubsumptionTableEntry::replaceExpr(ref<Expr> originalExpr,

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -2124,39 +2124,15 @@ bool Inequality::normalize(const Array *focusVariable) {
     ref<Expr> currExpr = lhsTermsIter->first;
     int64_t currCoefficient = lhsTermsIter->second;
 
-    if (SubsumptionTableEntry::isVariable(currExpr)) {
-      if (getArrayFromConcatExpr(currExpr) == focusVariable) {
-        // The variable of the current term is the focus variable.
-        if (newLhs.count(currExpr) > 0) {
-          newLhs[currExpr] = newLhs[currExpr] + currCoefficient;
-        } else {
-          newLhs[currExpr] = currCoefficient;
-        }
-        onFocusVarCoefficient = lhsTermsIter->second;
-        isOnFocusVarOnLeft = true;
-      } else {
-        // Move variable other than on focus existential variable to the rhs.
-        if (newRhs.count(currExpr) > 0) {
-          // The rhs already contains the lhs term's variable, subtract the
-          // term's coefficient with the lhs term's coefficient.
-          newRhs[currExpr] = newRhs[currExpr] - currCoefficient;
-        } else {
-          // The rhs does not contain the lhs term's variable, add the term
-          // to the rhs
-          newRhs[currExpr] = 0 - currCoefficient;
-        }
-      }
+    if (SubsumptionTableEntry::isVariable(currExpr) &&
+        getArrayFromConcatExpr(currExpr) == focusVariable) {
+      // The variable of the current term is the focus variable.
+      mergeTermToLinearExpression(newLhs, currExpr, currCoefficient);
+      onFocusVarCoefficient = lhsTermsIter->second;
+      isOnFocusVarOnLeft = true;
     } else {
-      // Move terms other than on focus existential variable to the rhs
-      if (newRhs.count(currExpr) > 0) {
-        // The rhs already contains the lhs term's variable, subtract the term's
-        // coefficient with the lhs term's coefficient.
-        newRhs[currExpr] = newRhs[currExpr] - currCoefficient;
-      } else {
-        // The rhs does not contain the lhs term's variable, add the term
-        // to the rhs
-        newRhs[currExpr] = 0 - currCoefficient;
-      }
+      // Move variable other than on focus existential variable to the rhs.
+      mergeTermToLinearExpression(newRhs, currExpr, 0 - currCoefficient);
     }
   }
 
@@ -2167,30 +2143,15 @@ bool Inequality::normalize(const Array *focusVariable) {
     ref<Expr> currExpr = rhsTermsIter->first;
     int64_t currCoefficient = rhsTermsIter->second;
 
-    if (SubsumptionTableEntry::isVariable(currExpr)) {
+    if (SubsumptionTableEntry::isVariable(currExpr) &&
+        getArrayFromConcatExpr(currExpr) == focusVariable) {
       // If we find on focus exist variable on the right hand side,
       // move it to the left hand side
-      if (getArrayFromConcatExpr(currExpr) == focusVariable) {
-        if (newLhs.count(currExpr) > 0) {
-          newLhs[currExpr] = newLhs[currExpr] - currCoefficient;
-        } else {
-          newLhs[currExpr] = 0 - currCoefficient;
-        }
-        onFocusVarCoefficient = newLhs[currExpr];
-        isOnFocusVarOnLeft = true;
-      } else {
-        if (newRhs.count(currExpr) > 0) {
-          newRhs[currExpr] = newRhs[currExpr] - currCoefficient;
-        } else {
-          newRhs[currExpr] = 0 - currCoefficient;
-        }
-      }
+      mergeTermToLinearExpression(newLhs, currExpr, 0 - currCoefficient);
+      onFocusVarCoefficient = newLhs[currExpr];
+      isOnFocusVarOnLeft = true;
     } else {
-      if (newRhs.count(currExpr) > 0) {
-        newRhs[currExpr] = newRhs[currExpr] - currCoefficient;
-      } else {
-        newRhs[currExpr] = 0 - currCoefficient;
-      }
+      mergeTermToLinearExpression(newRhs, currExpr, currCoefficient);
     }
   }
 

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -704,7 +704,9 @@ void SearchTree::includeInInterpolant(PathCondition *pathCondition) {
 
   assert(SearchTree::instance && "Search tree graph not initialized");
 
-  instance->pathConditionMap[pathCondition]->pathConditionTable[pathCondition].second = true;
+  instance->pathConditionMap[pathCondition]
+      ->pathConditionTable[pathCondition]
+      .second = true;
 }
 
 /// @brief Save the graph
@@ -1171,26 +1173,29 @@ SubsumptionTableEntry::simplifyMatching(std::map<ref<Expr>, int64_t> &left,
       ++itRight;
   }
 
-//  if(left.size() >= 1 && containsNonConstantExpr(left) && right.size() == 0){
-//	  right.insert(std::make_pair(ConstantExpr::alloc(0, left.begin()->first->getWidth()), 0));
-//  }
-//  else if(right.size() >= 1 && containsNonConstantExpr(right) && left.size() == 0){
-//	  left.insert(std::make_pair(ConstantExpr::alloc(0, right.begin()->first->getWidth()), 0));
-//  }
+  if (left.size() >= 1 && containsNonConstantExpr(left) && right.size() == 0) {
+    right.insert(std::make_pair(
+        ConstantExpr::alloc(0, left.begin()->first->getWidth()), 0));
+  } else if (right.size() >= 1 && containsNonConstantExpr(right) &&
+             left.size() == 0) {
+    left.insert(std::make_pair(
+        ConstantExpr::alloc(0, right.begin()->first->getWidth()), 0));
+  }
 }
 
-bool SubsumptionTableEntry::containsNonConstantExpr(std::map<ref<Expr>, int64_t> map){
-	for (std::map<ref<Expr>, int64_t>::iterator mIt = map.begin(),
-	                                              mEnd = map.end();
-			mIt != mEnd; ++mIt) {
-	  if(!llvm::isa<ConstantExpr>(mIt->first))
-		  return true;
-	}
-	return false;
+bool SubsumptionTableEntry::containsNonConstantExpr(
+    std::map<ref<Expr>, int64_t> map) {
+  for (std::map<ref<Expr>, int64_t>::iterator mIt = map.begin(),
+                                              mEnd = map.end();
+       mIt != mEnd; ++mIt) {
+    if (!llvm::isa<ConstantExpr>(mIt->first))
+      return true;
+  }
+  return false;
 }
 
 void SubsumptionTableEntry::normalization(const Array *onFocusExistential,
-                                          InequalityExpr * inequalityExpr,
+                                          InequalityExpr *inequalityExpr,
                                           bool &isOnFocusVarOnLeft) {
 
   std::map<ref<Expr>, int64_t> left = inequalityExpr->getLeft();
@@ -1216,8 +1221,8 @@ void SubsumptionTableEntry::normalization(const Array *onFocusExistential,
       // hand side
       // then, delete it from left map
       if (array == onFocusExistential) {
-    	onFocusVarCoefficient = itLeft->second;
-	    isOnFocusVarOnLeft = true;
+        onFocusVarCoefficient = itLeft->second;
+        isOnFocusVarOnLeft = true;
         ++itLeft;
       } else {
         currCoefficient = currCoefficient * -1;
@@ -1265,7 +1270,7 @@ void SubsumptionTableEntry::normalization(const Array *onFocusExistential,
         } else {
           left.insert(std::make_pair(itRight->first, currCoefficient));
         }
-    	onFocusVarCoefficient = itRight->second;
+        onFocusVarCoefficient = itRight->second;
         isOnFocusVarOnLeft = true;
         right.erase(itRight++);
       } else {
@@ -1277,44 +1282,46 @@ void SubsumptionTableEntry::normalization(const Array *onFocusExistential,
   }
 
   // divide both sides with onFocusVariable coefficient.
-  if(onFocusExistential && (onFocusVarCoefficient != 1 && onFocusVarCoefficient != 0)){
+  if (onFocusExistential &&
+      (onFocusVarCoefficient != 1 && onFocusVarCoefficient != 0)) {
     std::map<ref<Expr>, int64_t>::iterator itLeft = left.begin();
-	while (itLeft != left.end()) {
-	  itLeft->second = itLeft->second / onFocusVarCoefficient;
-	  ++itLeft;
-	}
+    while (itLeft != left.end()) {
+      itLeft->second = itLeft->second / onFocusVarCoefficient;
+      ++itLeft;
+    }
 
-	std::map<ref<Expr>, int64_t>::iterator itRight = right.begin();
-	while (itRight != right.end()) {
-	  itRight->second = itRight->second / onFocusVarCoefficient;
-	  ++itRight;
-	}
+    std::map<ref<Expr>, int64_t>::iterator itRight = right.begin();
+    while (itRight != right.end()) {
+      itRight->second = itRight->second / onFocusVarCoefficient;
+      ++itRight;
+    }
 
-	// if we divide with negative values, the Kind Expression would be reversed
-	if(onFocusVarCoefficient < 0){
-	  if(inequalityExpr->getKind() == Expr::Sle)
-	    inequalityExpr->updateKind(Expr::Sgt);
-	  else if(inequalityExpr->getKind() == Expr::Sge)
-		inequalityExpr->updateKind(Expr::Slt);
-	  else if(inequalityExpr->getKind() == Expr::Slt)
-		inequalityExpr->updateKind(Expr::Sge);
-	  else if(inequalityExpr->getKind() == Expr::Sgt)
-		inequalityExpr->updateKind(Expr::Sle);
-	}
+    // if we divide with negative values, the Kind Expression would be reversed
+    if (onFocusVarCoefficient < 0) {
+      if (inequalityExpr->getKind() == Expr::Sle)
+        inequalityExpr->updateKind(Expr::Sgt);
+      else if (inequalityExpr->getKind() == Expr::Sge)
+        inequalityExpr->updateKind(Expr::Slt);
+      else if (inequalityExpr->getKind() == Expr::Slt)
+        inequalityExpr->updateKind(Expr::Sge);
+      else if (inequalityExpr->getKind() == Expr::Sgt)
+        inequalityExpr->updateKind(Expr::Sle);
+    }
   }
 
-  if(left.size() >= 1 && containsNonConstantExpr(left) && right.size() == 0){
-    right.insert(std::make_pair(ConstantExpr::alloc(0, left.begin()->first->getWidth()), 0));
-  }
-  else if(right.size() >= 1 && containsNonConstantExpr(right) && left.size() == 0){
-  	left.insert(std::make_pair(ConstantExpr::alloc(0, right.begin()->first->getWidth()), 0));
+  if (left.size() >= 1 && containsNonConstantExpr(left) && right.size() == 0) {
+    right.insert(std::make_pair(
+        ConstantExpr::alloc(0, left.begin()->first->getWidth()), 0));
+  } else if (right.size() >= 1 && containsNonConstantExpr(right) &&
+             left.size() == 0) {
+    left.insert(std::make_pair(
+        ConstantExpr::alloc(0, right.begin()->first->getWidth()), 0));
   }
 
   if (left.size() > 0 && right.size() > 0) {
     inequalityExpr->updateLeft(left);
-	inequalityExpr->updateRight(right);
+    inequalityExpr->updateRight(right);
   }
-
 }
 
 std::map<ref<Expr>, int64_t>
@@ -1757,19 +1764,18 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
   for (std::vector<llvm::Value *>::iterator it = singletonStoreKeys.begin(),
                                             itEnd = singletonStoreKeys.end();
        it != itEnd; ++it) {
-      const ref<Expr> lhs = singletonStore[*it];
-      const ref<Expr> rhs = stateSingletonStore[*it];
+    const ref<Expr> lhs = singletonStore[*it];
+    const ref<Expr> rhs = stateSingletonStore[*it];
 
-      // If the current state does not constrain the same
-      // allocation, subsumption fails.
-      if (!rhs.get())
-        return false;
+    // If the current state does not constrain the same
+    // allocation, subsumption fails.
+    if (!rhs.get())
+      return false;
 
-      stateEqualityConstraints =
-          (!stateEqualityConstraints.get()
-               ? EqExpr::alloc(lhs, rhs)
-               : AndExpr::alloc(EqExpr::alloc(lhs, rhs),
-                                stateEqualityConstraints));
+    stateEqualityConstraints = (!stateEqualityConstraints.get()
+                                    ? EqExpr::alloc(lhs, rhs)
+                                    : AndExpr::alloc(EqExpr::alloc(lhs, rhs),
+                                                     stateEqualityConstraints));
   }
 
   for (std::vector<llvm::Value *>::iterator it = compositeStoreKeys.begin(),
@@ -1839,8 +1845,9 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
 
   if (!existentials.empty()) {
     ref<Expr> existsExpr = ExistsExpr::create(existentials, query);
-//     llvm::errs() << "Before simplification:\n";
-//     ExprPPrinter::printQuery(llvm::errs(), state.constraints, existsExpr);
+    //     llvm::errs() << "Before simplification:\n";
+    //     ExprPPrinter::printQuery(llvm::errs(), state.constraints,
+    // existsExpr);
     query = simplifyExistsExpr(existsExpr, queryHasNoFreeVariables);
   }
 
@@ -1851,8 +1858,8 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
   // We call the solver only when the simplified query is
   // not a constant.
   if (!llvm::isa<ConstantExpr>(query)) {
-//    llvm::errs() << "Querying for subsumption check:\n";
-//    ExprPPrinter::printQuery(llvm::errs(), state.constraints, query);
+    //    llvm::errs() << "Querying for subsumption check:\n";
+    //    ExprPPrinter::printQuery(llvm::errs(), state.constraints, query);
     ++checkSolverCount;
     if (!existentials.empty() && llvm::isa<ExistsExpr>(query)) {
       // llvm::errs() << "Existentials not empty\n";
@@ -1919,7 +1926,7 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
   }
 
   if (success && result == Solver::True) {
-//         llvm::errs() << "Solver decided validity\n";
+    //         llvm::errs() << "Solver decided validity\n";
     std::vector<ref<Expr> > unsatCore;
     if (z3solver) {
       unsatCore = z3solver->getUnsatCore();
@@ -2079,9 +2086,7 @@ void InequalityExpr::updateRight(std::map<ref<Expr>, int64_t> newRight) {
   right = newRight;
 }
 
-void InequalityExpr::updateKind(Expr::Kind newKind) {
-  kind = newKind;
-}
+void InequalityExpr::updateKind(Expr::Kind newKind) { kind = newKind; }
 
 /**/
 

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -2165,7 +2165,10 @@ Inequality::coefficientOperation(Expr::Kind kind,
 }
 
 bool Inequality::normalize(const Array *onFocusExistential) {
-  bool isOnFocusVarOnLeft = false;
+  bool isOnFocusVarOnLeft = false; // Denotes if the normalization successfully
+                                   // moved the focus variable to the lhs, such
+                                   // that the lhs only contains a term whose
+                                   // variable is the focus variable.
 
   std::map<ref<Expr>, int64_t> localLhs(lhs);
   std::map<ref<Expr>, int64_t> localRhs(rhs);

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1013,8 +1013,8 @@ SubsumptionTableEntry::simplifyWithFourierMotzkin(ref<Expr> existsExpr) {
        it != itEnd; ++it) {
     ref<Expr> currExpr = *it;
 
-    std::map<ref<Expr>, int64_t> left = getCoefficient(currExpr->getKid(0));
-    std::map<ref<Expr>, int64_t> right = getCoefficient(currExpr->getKid(1));
+    std::map<ref<Expr>, int64_t> left = getLinearTerms(currExpr->getKid(0));
+    std::map<ref<Expr>, int64_t> right = getLinearTerms(currExpr->getKid(1));
     inequalityPack.push_back(
         new InequalityExpr(left, right, currExpr->getKind(), currExpr));
   }
@@ -1028,8 +1028,8 @@ SubsumptionTableEntry::simplifyWithFourierMotzkin(ref<Expr> existsExpr) {
        it != itEnd; ++it) {
     ref<Expr> currExpr = *it;
 
-    std::map<ref<Expr>, int64_t> left = getCoefficient(currExpr->getKid(0));
-    std::map<ref<Expr>, int64_t> right = getCoefficient(currExpr->getKid(1));
+    std::map<ref<Expr>, int64_t> left = getLinearTerms(currExpr->getKid(0));
+    std::map<ref<Expr>, int64_t> right = getLinearTerms(currExpr->getKid(1));
     inequalityPack.push_back(
         new InequalityExpr(left, right, currExpr->getKind(), currExpr));
   }
@@ -1492,14 +1492,14 @@ bool SubsumptionTableEntry::normalize(const Array *onFocusExistential,
 }
 
 std::map<ref<Expr>, int64_t>
-SubsumptionTableEntry::getCoefficient(ref<Expr> expr) {
+SubsumptionTableEntry::getLinearTerms(ref<Expr> expr) {
   std::map<ref<Expr>, int64_t> map;
   if (expr->getNumKids() == 2 && !isVariable(expr)) {
     llvm::errs() << "CASE A: ";
     expr->dump();
     return coefficientOperation(expr->getKind(),
-                                getCoefficient(expr->getKid(0)),
-                                getCoefficient(expr->getKid(1)));
+                                getLinearTerms(expr->getKid(0)),
+                                getLinearTerms(expr->getKid(1)));
   }
 
   if (expr->getNumKids() < 2 || isVariable(expr)) {

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1039,7 +1039,11 @@ SubsumptionTableEntry::simplifyArithmeticBody(ref<Expr> existsExpr,
     newBody = AndExpr::alloc(simplifiedInterpolant, fullEqualityConstraint);
   }
 
-  return existsExpr->rebuild(&newBody);
+  // This return is only used if Fourier-Motzkin is called in
+  // SubsumptionTableEntry::subsumed
+  // return existsExpr->rebuild(&newBody);
+
+  return FourierMotzkin::simplify(existsExpr->rebuild(&newBody));
 }
 
 ref<Expr> SubsumptionTableEntry::replaceExpr(ref<Expr> originalExpr,
@@ -1381,11 +1385,12 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
     //     ExprPPrinter::printQuery(llvm::errs(), state.constraints,
     // existsExpr);
     query = simplifyExistsExpr(existsExpr, queryHasNoFreeVariables);
-    if (query.operator==(existsExpr)) {
-      simplifywithFourierTimer.start();
-      query = FourierMotzkin::simplify(query);
-      simplifywithFourierTimer.stop();
-    }
+    // commented as this modification may reduce the number of subsumptions
+    // if (query.operator==(existsExpr)) {
+    // simplifywithFourierTimer.start();
+    // query = FourierMotzkin::simplify(query);
+    // simplifywithFourierTimer.stop();
+    //}
   }
 
   // If query simplification result was false, we quickly fail without calling

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1084,7 +1084,6 @@ SubsumptionTableEntry::simplifyWithFourierMotzkin(ref<Expr> existsExpr) {
         InequalityExpr::match(lessThanPack, greaterThanPack, strictLessThanPack,
                               strictGreaterThanPack);
 
-    llvm::errs() << "-";
     inequalityPack = resultPack;
     inequalityPack.insert(inequalityPack.end(), nonePack.begin(),
                           nonePack.end());
@@ -2195,8 +2194,7 @@ bool InequalityExpr::normalize(const Array *onFocusExistential) {
         // hand side then, delete it from left map
         if (rhs.count(lhsTermsIter->first) > 0) {
           // The rhs already contains the lhs term's variable, subtract the
-          // term's
-          // coefficient with the lhs term's coefficient.
+          // term's coefficient with the lhs term's coefficient.
           rhs.at(lhsTermsIter->first) =
               rhs.at(lhsTermsIter->first) - currCoefficient;
         } else {
@@ -2269,14 +2267,26 @@ bool InequalityExpr::normalize(const Array *onFocusExistential) {
 
     // If we divide with negative values, the expression's Kind will be reversed
     if (onFocusVarCoefficient < 0) {
-      if (inequalityExpr->getKind() == Expr::Sle)
-        kind = Expr::Sgt;
-      else if (inequalityExpr->getKind() == Expr::Sge)
-        kind = Expr::Slt;
-      else if (inequalityExpr->getKind() == Expr::Slt)
+      switch (kind) {
+      case Expr::Sle: {
         kind = Expr::Sge;
-      else if (inequalityExpr->getKind() == Expr::Sgt)
+        break;
+      }
+      case Expr::Sge: {
         kind = Expr::Sle;
+        break;
+      }
+      case Expr::Slt: {
+        kind = Expr::Sgt;
+        break;
+      }
+      case Expr::Sgt: {
+        kind = Expr::Slt;
+        break;
+      }
+      default:
+        break;
+      }
     }
   }
 
@@ -2285,7 +2295,6 @@ bool InequalityExpr::normalize(const Array *onFocusExistential) {
         ConstantExpr::alloc(0, lhs.begin()->first->getWidth()), 0));
   } else if (rhs.size() >= 1 && containsNonConstantExpr(rhs) &&
              lhs.size() == 0) {
-    llvm::errs() << "LHS SIZE IS 0\n";
     lhs.insert(std::make_pair(
         ConstantExpr::alloc(0, rhs.begin()->first->getWidth()), 0));
   }

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1369,7 +1369,7 @@ bool SubsumptionTableEntry::normalize(const Array *onFocusExistential,
     ref<Expr> currExpr = lhsTermsIter->first;
     int64_t currCoefficient = lhsTermsIter->second;
 
-    if (llvm::isa<ConcatExpr>(currExpr)) {
+    if (isVariable(currExpr)) {
       if (getArrayFromConcatExpr(currExpr) == onFocusExistential) {
         // The variable of the current term is the focus variable.
         onFocusVarCoefficient = lhsTermsIter->second;
@@ -1417,7 +1417,7 @@ bool SubsumptionTableEntry::normalize(const Array *onFocusExistential,
     ref<Expr> currExpr = rhsTermsIter->first;
     int64_t currCoefficient = rhsTermsIter->second;
 
-    if (llvm::isa<ConcatExpr>(currExpr)) {
+    if (isVariable(currExpr)) {
       if (getArrayFromConcatExpr(currExpr) == onFocusExistential) {
         if (lhs.count(rhsTermsIter->first) > 0) {
           lhs.at(rhsTermsIter->first) =
@@ -1488,7 +1488,7 @@ bool SubsumptionTableEntry::normalize(const Array *onFocusExistential,
 std::map<ref<Expr>, int64_t>
 SubsumptionTableEntry::getCoefficient(ref<Expr> expr) {
   std::map<ref<Expr>, int64_t> map;
-  if (expr->getNumKids() == 2 && !llvm::isa<ConcatExpr>(expr)) {
+  if (expr->getNumKids() == 2 && !isVariable(expr)) {
     llvm::errs() << "CASE A: ";
     expr->dump();
     return coefficientOperation(expr->getKind(),
@@ -1496,7 +1496,7 @@ SubsumptionTableEntry::getCoefficient(ref<Expr> expr) {
                                 getCoefficient(expr->getKid(1)));
   }
 
-  if (expr->getNumKids() < 2 || llvm::isa<ConcatExpr>(expr)) {
+  if (expr->getNumKids() < 2 || isVariable(expr)) {
     llvm::errs() << "CASE B: ";
     expr->dump();
     if (llvm::isa<ConstantExpr>(expr)) {
@@ -1916,7 +1916,7 @@ SubsumptionTableEntry::getSubstitution(ref<Expr> equalities,
                                        std::map<ref<Expr>, ref<Expr> > &map) {
   if (llvm::isa<EqExpr>(equalities.get())) {
     ref<Expr> lhs = equalities->getKid(0);
-    if (llvm::isa<ReadExpr>(lhs.get()) || llvm::isa<ConcatExpr>(lhs.get())) {
+    if (isVariable(lhs)) {
       map[lhs] = equalities->getKid(1);
       return ConstantExpr::alloc(1, Expr::Bool);
     }

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -149,9 +149,410 @@ SubsumptionTableEntry::hasExistentials(std::vector<const Array *> &existentials,
 
 ref<Expr>
 SubsumptionTableEntry::simplifyWithFourierMotzkin(ref<Expr> existsExpr) {
-  // This is a template for Fourier-Motzkin elimination. For now,
-  // we simply return the input argument.
-  return existsExpr;
+  ExistsExpr *expr = static_cast<ExistsExpr *>(existsExpr.get());
+  std::vector<const Array *> boundVariables = expr->variables;
+  ref<Expr> body = expr->body;
+  std::vector<ref<Expr> > interpolantPack;
+  std::vector<ref<Expr> > equalityPack;
+
+  // We only simplify a conjunction of interpolant and equalities
+  if (!llvm::isa<AndExpr>(body))
+    return existsExpr;
+
+  // If the post-simplified body was a constant, simply return the body;
+  if (llvm::isa<ConstantExpr>(body))
+    return body;
+
+  // The equality constraint is only a single disjunctive clause
+  // of a CNF formula. In this case we simplify nothing.
+  if (llvm::isa<OrExpr>(body->getKid(1)))
+    return existsExpr;
+  equalityPack.clear();
+  ref<Expr> fullEqualityConstraint =
+    simplifyEqualityExpr(equalityPack, body->getKid(1));
+
+  interpolantPack.clear();
+  ref<Expr> simplifiedInterpolant =
+    simplifyInterpolantExpr(interpolantPack, body->getKid(0));
+  if (llvm::isa<ConstantExpr>(simplifiedInterpolant))
+    return fullEqualityConstraint;
+
+  std::vector<InequalityExpr *> inequalityPack;
+
+  // STEP 1a: represent Klee expression in equality pack
+  // into InequalityExpr data structure that enable us to do arithmetic operation
+  for (std::vector<ref<Expr> >::iterator it = equalityPack.begin(),
+  		                                itEnd = equalityPack.end();
+
+	       it != itEnd; ++it) {
+      ref<Expr> currExpr = *it;
+      std::map<ref<Expr>, int64_t > left = getCoefficient(currExpr->getKid(0));
+	  std::map<ref<Expr>, int64_t > right =getCoefficient(currExpr->getKid(1));
+
+      InequalityExpr *ineq1 = new InequalityExpr(left, right, Expr::Sle, currExpr);
+      InequalityExpr *ineq2 = new InequalityExpr(left, right, Expr::Sge, currExpr);
+
+      inequalityPack.push_back(ineq1);
+      inequalityPack.push_back(ineq2);
+  }
+
+  // STEP 1b: represent Klee expression in interpolant pack
+  // into InequalityExpr data structure that enable us to do arithmetic operation
+  for (std::vector<ref<Expr> >::iterator it = interpolantPack.begin(),
+		                                itEnd = interpolantPack.end();
+	       it != itEnd; ++it) {
+
+     ref<Expr> currExpr = *it;
+	 std::map<ref<Expr>, int64_t > left = getCoefficient(currExpr->getKid(0));
+	 std::map<ref<Expr>, int64_t > right = getCoefficient(currExpr->getKid(1));
+     InequalityExpr *ineq = new InequalityExpr(left, right, currExpr->getKind(), currExpr);
+     inequalityPack.push_back(ineq);
+  }
+
+  //STEP 2: core of fourier-montzkin algorithm
+  for (std::vector<const Array *>::iterator xit = boundVariables.begin(),
+     	                xitEnd = boundVariables.end();
+		  	  	  	  	xit != xitEnd; ++xit) {
+	  const Array * currExistVar = *xit;
+
+	  std::vector<InequalityExpr *> lessThanPack;
+	  std::vector<InequalityExpr *> greaterThanPack;
+	  std::vector<InequalityExpr *> nonePack;
+
+	  //STEP 2a: normalized the inequality expression into the
+	  //form such that exist variables are located on the left hand side
+	  for(std::vector<InequalityExpr *>::iterator inqt = inequalityPack.begin(),
+		  	  	  	  	inqtEnd = inequalityPack.end();
+			  	  	  	inqt != inqtEnd; ++inqt){
+
+		  InequalityExpr * currIneq = *inqt;
+		  std::map<ref<Expr>, int64_t > newLeft = currIneq->getLeft();
+		  std::map<ref<Expr>, int64_t > newRight = currIneq->getRight();
+
+		  normalization(currExistVar, currIneq->getKind(), newLeft, newRight);
+
+		  currIneq->updateLeft(newLeft);
+		  currIneq->updateRight(newRight);
+
+		  //STEP 2b: divide the inequalityPack into 3 separated pack
+		  //based on its operator existVar <= (lessThanPack), existVar >= (greaterThanPack),
+		  //or (nonePack) if there's no on focus exist variable in the equation.
+		  classification(currExistVar, currIneq, lessThanPack, greaterThanPack, nonePack);
+      }
+
+	  //STEP 3: matching between inequality
+	  std::vector<InequalityExpr *> resultPack;
+	  resultPack = matching(lessThanPack, greaterThanPack);
+	  inequalityPack.clear();
+	  inequalityPack.insert(inequalityPack.end(), resultPack.begin(), resultPack.end());
+	  inequalityPack.insert(inequalityPack.end(), nonePack.begin(), nonePack.end());
+  }
+
+  //STEP 4: reconstruct the result back to Klee Expr
+  if(inequalityPack.size() ==0 )
+	  return existsExpr;
+  ref<Expr> result = reconstructExpr(inequalityPack);
+  return result;
+}
+
+ref<Expr> SubsumptionTableEntry::reconstructExpr(std::vector<InequalityExpr *> inequalityPack){
+	ref<Expr> result;
+
+	for (std::vector<InequalityExpr *>::iterator it1 = inequalityPack.begin(),
+		 		                                it1End = inequalityPack.end();
+		 	       it1 != it1End; ++it1) {
+
+		InequalityExpr * currInequality = *it1;
+		ref<Expr> temp;
+		ref<Expr> leftExpr;
+		ref<Expr> rightExpr;
+
+		for (std::map<ref<Expr>, int64_t >::iterator l = currInequality->getLeft().begin(),
+				 		                                lEnd = currInequality->getLeft().end();
+						l != lEnd; ++l) {
+
+			ref<Expr> tempLeft;
+			if(llvm::isa<ConstantExpr>(l->first)){
+				tempLeft = ConstantExpr::create(l->second, l->first->getWidth());
+			}else{
+				tempLeft = l->first;
+				if(l->second > 1){
+					tempLeft = MulExpr::create(tempLeft, ConstantExpr::create(l->second, l->first->getWidth()));
+				}
+			}
+
+			if(leftExpr.get()){
+				leftExpr = AddExpr::create(leftExpr, tempLeft);
+			}else{
+				leftExpr = tempLeft;
+			}
+		}
+
+		for (std::map<ref<Expr>, int64_t >::iterator r = currInequality->getRight().begin(),
+				 		                                rEnd = currInequality->getRight().end();
+						r != rEnd; ++r) {
+
+			ref<Expr> currExpr = r->first;
+			ref<Expr> tempRight;
+			if(llvm::isa<ConstantExpr>(r->first)){
+				tempRight = ConstantExpr::create(r->second, r->first->getWidth());
+			}else{
+				tempRight = r->first;
+				if(r->second > 1){
+					tempRight = MulExpr::create(tempRight, ConstantExpr::create(r->second, r->first->getWidth()));
+				}
+			}
+
+			if(rightExpr.get()){
+				rightExpr = AddExpr::create(rightExpr, tempRight);
+			}else{
+				rightExpr = tempRight;
+			}
+		}
+		temp = createBinaryExpr(currInequality->getKind(), leftExpr, rightExpr);
+
+		if(result.get()){
+			result = AndExpr::alloc(result, temp);
+		}
+		else{
+			result = temp;
+		}
+	}
+	return result;
+}
+
+void SubsumptionTableEntry::classification(const Array *onFocusExistential, InequalityExpr * currIneq, std::vector<InequalityExpr *> &lessThanPack,
+		std::vector<InequalityExpr *> &greaterThanPack, std::vector<InequalityExpr *> &nonePack){
+  if(currIneq->getLeft().size() == 1){
+	  if(currIneq->getKind() ==  Expr::Sle)
+		  lessThanPack.push_back(currIneq);
+	  else if(currIneq->getKind() ==  Expr::Sge)
+		  greaterThanPack.push_back(currIneq);
+  }else{
+	  nonePack.push_back(currIneq);
+  }
+
+}
+// assume lessThanPack: (shadow_expr <= a) and greaterThanPack: (shadow_expr >= b), it would be b <= a
+// greaterThanPack.right <= lessThanPack.right
+std::vector<InequalityExpr *> SubsumptionTableEntry::matching(std::vector<InequalityExpr *> lessThanPack, std::vector<InequalityExpr *> greaterThanPack){
+	std::vector<InequalityExpr *> result;
+
+	for (std::vector<InequalityExpr *>::iterator it1 = lessThanPack.begin(),
+	 		                                it1End = lessThanPack.end();
+	 	       it1 != it1End; ++it1) {
+		  InequalityExpr * currLT = *it1;
+		  std::map<ref<Expr>, int64_t > right = currLT->getRight();
+
+		  for (std::vector<InequalityExpr *>::iterator it2 = greaterThanPack.begin(),
+		   		                                it2End = greaterThanPack.end();
+		   	       it2 != it2End; ++it2) {
+			  InequalityExpr * currGT = *it2;
+			  std::map<ref<Expr>, int64_t > left = currGT->getRight();
+			  simplifyMatching(left, right);
+			  if(left.size() > 0 && right.size() > 0){
+				  InequalityExpr *ineq = new InequalityExpr(left, right, Expr::Sle, NULL);
+				  result.push_back(ineq);
+			  }
+		  }
+	}
+	return result;
+}
+
+void SubsumptionTableEntry::simplifyMatching(std::map<ref<Expr>, int64_t > &left, std::map<ref<Expr>, int64_t > &right){
+	for (std::map<ref<Expr>, int64_t >::iterator l = left.begin(),
+		 		                                lEnd = left.end();
+				l != lEnd; ++l) {
+
+		for (std::map<ref<Expr>, int64_t >::iterator r = right.begin(),
+					 		                        rEnd = right.end();
+							r != rEnd; ++r) {
+
+		    if(r->first.operator ==(l->first)){
+				if(l->second > r->second){
+					l->second = l->second - r->second;
+					r->second = 0;
+				}
+				else if(l->second < r->second){
+					r->second = r->second - l->second;
+					l->second = 0;
+				}
+				else if(l->second == r->second){
+					l->second = 0;
+					r->second = 0;
+				}
+		  }
+	  }
+  }
+
+  std::map<ref<Expr>, int64_t >::iterator itLeft = left.begin();
+  while(itLeft != left.end()) {
+	  if(itLeft->second == 0)
+		  left.erase(itLeft++);
+	  else
+		  ++itLeft;
+  }
+
+  std::map<ref<Expr>, int64_t >::iterator itRight = right.begin();
+    while(itRight != right.end()) {
+  	  if(itRight->second == 0)
+  		right.erase(itRight++);
+  	  else
+  		  ++itRight;
+   }
+}
+
+void SubsumptionTableEntry::normalization(const Array *onFocusExistential, Expr::Kind kind, std::map<ref<Expr>, int64_t > &left, std::map<ref<Expr>, int64_t > &right){
+
+	std::map<ref<Expr>, int64_t >::iterator itLeft = left.begin();
+
+	while(itLeft != left.end()) {
+
+		if(llvm::isa<ReadExpr>(itLeft->first)){
+			ReadExpr *readExpr = llvm::dyn_cast<ReadExpr>(itLeft->first.get());
+		    const Array *array = (readExpr->updates).root;
+
+		    // move variable other than on focus existential variable to the right hand side
+		    // then, delete it from left map
+		    if(array != onFocusExistential){
+		    	itLeft->second = itLeft->second * -1;
+				ref<Expr> tempFirst = itLeft->first;
+				int64_t tempSecond = itLeft->second;
+
+				if(right.count(tempFirst) > 0){ // contains
+					right.at(tempFirst) = right.at(tempFirst) + tempSecond;
+				}
+				else{
+					right.insert(std::make_pair(tempFirst, tempSecond));
+				}
+		    	left.erase(itLeft++);
+
+		    }
+		    else{
+		    	++itLeft;
+		    }
+		}
+		else if(llvm::isa<ConstantExpr>(itLeft->first)){
+			itLeft->second = itLeft->second * -1;
+			ref<Expr> tempFirst = itLeft->first;
+			int64_t tempSecond = itLeft->second;
+
+			if(right.count(tempFirst) > 0){
+				right.at(tempFirst) = right.at(tempFirst) + tempSecond;
+			}
+			else{
+				right.insert(std::make_pair(tempFirst, tempSecond));
+			}
+			left.erase(itLeft++);
+		}
+		else{
+			++itLeft;
+		}
+
+	}
+
+	//if we find on focus exist variable on the right hand side,
+	//move it to the left hand side
+	std::map<ref<Expr>, int64_t >::iterator itRight = right.begin();
+	while(itRight != right.end()) {
+		if(llvm::isa<ReadExpr>(itRight->first)){
+		  ReadExpr *readExpr = llvm::dyn_cast<ReadExpr>(itRight->first.get());
+		  const Array *array = (readExpr->updates).root;
+
+		  if(array == onFocusExistential){
+		    itRight->second = itRight->second * -1;
+			//left.insert(*itRight);
+			ref<Expr> tempFirst = itRight->first;
+			int64_t tempSecond = itRight->second;
+			if(left.count(tempFirst) >  0){
+				left.at(tempFirst) = left.at(tempFirst) + tempSecond;
+			}
+			else{
+				left.insert(std::make_pair(tempFirst, tempSecond));
+			}
+			right.erase(itRight++);
+		  }
+		}
+		else{
+			++itRight;
+		}
+	}
+}
+
+std::map<ref<Expr>, int64_t > SubsumptionTableEntry::getCoefficient(ref<Expr> expr){
+  std::map<ref<Expr>, int64_t > map;
+  if(expr->getNumKids() == 2 && !llvm::isa<ConcatExpr>(expr)){
+    return coefficientOperation(expr->getKind(),getCoefficient(expr->getKid(0)), getCoefficient(expr->getKid(1)));
+  }
+
+  if(expr->getNumKids() < 2 || llvm::isa<ConcatExpr>(expr)){
+    if(llvm::isa<ConstantExpr>(expr))
+      map.insert(std::make_pair(ConstantExpr::alloc(0, expr->getWidth()),
+    		                  llvm::dyn_cast<ConstantExpr>(expr.get())->getAPValue().getSExtValue()));
+    else{
+      int64_t count = 1;
+      map.insert(std::make_pair(expr, count));
+    }
+  }
+
+  return map;
+}
+
+std::map<ref<Expr>, int64_t > SubsumptionTableEntry::coefficientOperation(Expr::Kind kind, std::map<ref<Expr>, int64_t > map1, std::map<ref<Expr>, int64_t > map2){
+
+  for (std::map<ref<Expr>, int64_t >::iterator it1 = map1.begin(),
+ 		                                it1End = map1.end();
+ 	       it1 != it1End; ++it1) {
+
+	  ref<Expr> expr1 = it1->first;
+	  bool isFound = false;
+	  for (std::map<ref<Expr>, int64_t >::iterator it2 = map2.begin(),
+	   		                                it2End = map2.end();
+	   	       it2 != it2End; ++it2) {
+
+		  ref<Expr> expr2 = it2->first;
+		  if(expr1.operator ==(expr2)){
+              if(kind == Expr::Add){
+                it2->second = it1->second + it2->second;
+              }
+              else if(kind == Expr::Sub){
+            	it2->second = it1->second - it2->second;
+              }
+              isFound = true;
+			  break;
+		  }
+	  }
+
+	  if(!isFound){
+		  map2.insert(std::make_pair(it1->first, it1->second));
+	  }
+  }
+
+  return map2;
+}
+
+void SubsumptionTableEntry::normalizeExpr(std::vector<ref <Expr> > equalityPack, std::vector<ref <Expr> > &inequalityPack){
+  for (std::vector<ref<Expr> >::iterator it = equalityPack.begin(),
+		                                itEnd = equalityPack.end();
+	       it != itEnd; ++it) {
+
+     ref<Expr> equalityConstraint = *it;
+
+     inequalityPack.push_back(createBinaryExpr(Expr::Sle, equalityConstraint->getKid(0), equalityConstraint->getKid(1)));
+     inequalityPack.push_back(createBinaryExpr(Expr::Sle, equalityConstraint->getKid(1), equalityConstraint->getKid(0)));
+
+   }
+}
+
+ref<Expr> SubsumptionTableEntry::createBinaryExpr(Expr::Kind kind,
+													ref<Expr> lhs,
+												    ref<Expr> rhs) {
+  std::vector<Expr::CreateArg> exprs;
+  Expr::CreateArg arg1(lhs);
+  Expr::CreateArg arg2(rhs);
+  exprs.push_back(arg1);
+  exprs.push_back(arg2);
+  return Expr::createFromKind(kind, exprs);
 }
 
 ref<Expr> SubsumptionTableEntry::simplifyArithmeticBody(ref<Expr> existsExpr) {
@@ -447,7 +848,7 @@ ref<Expr> SubsumptionTableEntry::simplifyEqualityExpr(
 ref<Expr> SubsumptionTableEntry::simplifyExistsExpr(ref<Expr> existsExpr) {
   assert(llvm::isa<ExistsExpr>(existsExpr));
 
-  ref<Expr> ret = simplifyArithmeticBody(existsExpr);
+  ref<Expr> ret = simplifyWithFourierMotzkin(existsExpr);
   if (llvm::isa<ExistsExpr>(ret))
     return ret;
 
@@ -556,8 +957,8 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
   // We call the solver only when the simplified query is
   // not a constant.
   if (!llvm::isa<ConstantExpr>(query)) {
-    // llvm::errs() << "Querying for subsumption check:\n";
-    // ExprPPrinter::printQuery(llvm::errs(), state.constraints, query);
+//     llvm::errs() << "Querying for subsumption check:\n";
+//     ExprPPrinter::printQuery(llvm::errs(), state.constraints, query);
 
     if (!existentials.empty() && llvm::isa<ExistsExpr>(query)) {
       // llvm::errs() << "Existentials not empty\n";
@@ -591,7 +992,7 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
   }
 
   if (success && result == Solver::True) {
-    // llvm::errs() << "Solver decided validity\n";
+//     llvm::errs() << "Solver decided validity\n";
     std::vector<ref<Expr> > unsatCore;
     if (z3solver) {
       unsatCore = z3solver->getUnsatCore();
@@ -704,6 +1105,33 @@ void SubsumptionTableEntry::print(llvm::raw_ostream &stream) const {
     }
     stream << "]\n";
   }
+}
+
+/**/
+
+InequalityExpr::InequalityExpr(std::map<ref<Expr>, int64_t > left, std::map<ref<Expr>,
+		int64_t > right, Expr::Kind kind, ref<Expr> originalExpr):
+	     left(left),
+		 right(right),
+		 kind(kind),
+		 originalExpr(originalExpr){}
+
+InequalityExpr::~InequalityExpr() {}
+
+std::map<ref<Expr>, int64_t > InequalityExpr::getLeft() { return left; }
+
+std::map<ref<Expr>, int64_t > InequalityExpr::getRight() { return right; }
+
+Expr::Kind InequalityExpr::getKind() { return kind; }
+
+ref<Expr> InequalityExpr::getOriginalExpr() { return originalExpr; }
+
+void InequalityExpr::updateLeft(std::map<ref<Expr>, int64_t > newLeft){
+	left = newLeft;
+}
+
+void InequalityExpr::updateRight(std::map<ref<Expr>, int64_t > newRight){
+	right = newRight;
 }
 
 /**/

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1121,7 +1121,7 @@ SubsumptionTableEntry::simplifyWithFourierMotzkin(ref<Expr> existsExpr) {
 }
 
 ref<Expr> SubsumptionTableEntry::reconstructExpr(
-    std::vector<InequalityExpr *> inequalityPack) {
+    std::vector<InequalityExpr *> &inequalityPack) {
   ref<Expr> result;
 
   for (std::vector<InequalityExpr *>::iterator
@@ -1141,12 +1141,18 @@ ref<Expr> SubsumptionTableEntry::reconstructExpr(
              lhsTermsIter = currInequality->getLhs().begin(),
              lhsTermsIterEnd = currInequality->getLhs().end();
          lhsTermsIter != lhsTermsIterEnd; ++lhsTermsIter) {
+      if (lhsTermsIter == lhsTermsIterEnd) {
+        llvm::errs() << "YYY\n";
+      }
       llvm::errs() << "X\n";
+      lhsTermsIter->first->dump();
+      llvm::errs() << "XX: " << lhsTermsIter->second << "\n";
       ref<Expr> tmp;
 
       if (!lhsTermsIter->first.get()) {
         llvm::errs() << "NULL FOUND\n";
       }
+
       if (llvm::isa<ConstantExpr>(lhsTermsIter->first)) {
         llvm::errs() << "FOUND CONSTANT: ";
         lhsTermsIter->first->dump();
@@ -1163,7 +1169,7 @@ ref<Expr> SubsumptionTableEntry::reconstructExpr(
       }
 
       if (lhsExpr.get()) {
-        lhsExpr = AddExpr::create(lhsExpr, tmp);
+        lhsExpr = AddExpr::alloc(lhsExpr, tmp);
       } else {
         lhsExpr = tmp;
       }

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -813,8 +813,8 @@ void PathCondition::print(llvm::raw_ostream &stream) const {
 }
 
 /**/
-StatTimer SubsumptionTableEntry::fourierMotzkinSimplifyTimer;
 
+StatTimer SubsumptionTableEntry::fourierMotzkinSimplifyTimer;
 StatTimer SubsumptionTableEntry::actualSolverCallTimer;
 
 unsigned long SubsumptionTableEntry::checkSolverCount = 0;
@@ -1519,9 +1519,8 @@ bool SubsumptionTableEntry::subsumed(
 
   if (!existentials.empty()) {
     ref<Expr> existsExpr = ExistsExpr::create(existentials, query);
-    //     llvm::errs() << "Before simplification:\n";
-    //     ExprPPrinter::printQuery(llvm::errs(), state.constraints,
-    // existsExpr);
+    // llvm::errs() << "Before simplification:\n";
+    // ExprPPrinter::printQuery(llvm::errs(), state.constraints, existsExpr);
     query = simplifyExistsExpr(existsExpr, queryHasNoFreeVariables);
 
     // *** The following applies Fourier-Motzkin elimination more
@@ -1555,9 +1554,10 @@ bool SubsumptionTableEntry::subsumed(
   // not a constant and no contradictory unary constraints found from
   // solvingUnaryConstraints method.
   if (!llvm::isa<ConstantExpr>(query)) {
-    //    llvm::errs() << "Querying for subsumption check:\n";
-    //    ExprPPrinter::printQuery(llvm::errs(), state.constraints, query);
+    // llvm::errs() << "Querying for subsumption check:\n";
+    // ExprPPrinter::printQuery(llvm::errs(), state.constraints, query);
     ++checkSolverCount;
+
     if (!existentials.empty() && llvm::isa<ExistsExpr>(query)) {
       // llvm::errs() << "Existentials not empty\n";
 
@@ -1641,7 +1641,7 @@ bool SubsumptionTableEntry::subsumed(
   }
 
   if (success && result == Solver::True) {
-    //         llvm::errs() << "Solver decided validity\n";
+    // llvm::errs() << "Solver decided validity\n";
     std::vector<ref<Expr> > unsatCore;
     if (z3solver) {
       unsatCore = z3solver->getUnsatCore();

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -119,6 +119,8 @@ class SubsumptionTableEntry {
   static ref<Expr> simplifyEqualityExpr(std::vector<ref<Expr> > &equalityPack,
                                         ref<Expr> expr);
 
+  static ref<Expr> simplifyWithFourierMotzkin(ref<Expr> existsExpr);
+
   static ref<Expr> simplifyExistsExpr(ref<Expr> existsExpr);
 
   static ref<Expr> simplifyArithmeticBody(ref<Expr> existsExpr);

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -338,11 +338,13 @@ class Inequality {
                            std::vector<Inequality *> pack2,
                            std::vector<Inequality *> &result);
 
-  static bool containsNonConstantExpr(std::map<ref<Expr>, int64_t> map);
-
   static void
   mergeTermToLinearExpression(std::map<ref<Expr>, int64_t> &linearExpr,
                               ref<Expr> &expr, int64_t coefficient) {
+    // Don't add anythingn whose coefficient is zero.
+    if (!coefficient)
+      return;
+
     if (linearExpr.count(expr) > 0) {
       // The linear expression already contains the term's variable, add the
       // term's coefficient with the linear expression term's coefficient.
@@ -364,11 +366,13 @@ public:
 
   /// Normalize the current inequality by bringing the term with focus
   /// variable to the lhs and the rest of the expressions to the rhs.
+  /// In case the focus variable is nonexistent, the lhs will contain
+  /// a single constant 0 term.
   ///
   /// \param The focus variable (a KLEE array).
   /// \return Success status, where true means that the procedure
-  ///         successfully brought the term with focus variable to the
-  //          rhs of the inequality.
+  ///         successfully resulted in informative normalized inequality,
+  //          where some terms are non-constant, and false otherwise.
   bool normalize(const Array *onFocusExistential);
 
   /// This operation sets the elimination status bit to true
@@ -392,6 +396,8 @@ public:
         std::vector<Inequality *> greaterThanPack,
         std::vector<Inequality *> strictLessThanPack,
         std::vector<Inequality *> strictGreaterThanPack);
+
+  static bool containsNonConstantExpr(std::map<ref<Expr>, int64_t> map);
 
   void dump() const {
     this->print(llvm::errs());
@@ -461,8 +467,7 @@ class SubsumptionTableEntry {
                        std::vector<Inequality *> &greaterThanPack,
                        std::vector<Inequality *> &nonePack,
                        std::vector<Inequality *> &strictLessThanPack,
-                       std::vector<Inequality *> &strictGreaterThanPack,
-                       bool isOnFocusVarOnLeft);
+                       std::vector<Inequality *> &strictGreaterThanPack);
 
   static ref<Expr> simplifyConcatExpr(ref<Expr> expr);
 

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -57,7 +57,6 @@ public:
   double get() { return (amount / (double)CLOCKS_PER_SEC); }
 };
 
-
 /// Storage of search tree for displaying
 class SearchTree {
 
@@ -371,7 +370,7 @@ class SubsumptionTableEntry {
                        std::map<ref<Expr>, int64_t> map2);
 
   static void normalization(const Array *onFocusExistential,
-		  	  	  	  	  	InequalityExpr * inequalityExpr,
+                            InequalityExpr *inequalityExpr,
                             bool &isOnFocusVarOnLeft);
 
   static void
@@ -449,7 +448,6 @@ public:
   void dump() const;
 
   void print(llvm::raw_ostream &stream) const;
-
 };
 
 class ITree {

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -468,6 +468,10 @@ class SubsumptionTableEntry {
     }
   };
 
+  /// @brief Statistics for simplify expression with Fourier execution time in
+  /// subsumption check
+  static StatTimer simplifywithFourierTimer;
+
   /// @brief Statistics for actual solver call time in subsumption check
   static StatTimer actualSolverCallTimer;
 

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -87,22 +87,24 @@ public:
   void mayIncludeInInterpolant();
 };
 
-class InequalityExpr{
-  std::map<ref<Expr>, int64_t > left;
-  std::map<ref<Expr>, int64_t > right;
+class InequalityExpr {
+  std::map<ref<Expr>, int64_t> left;
+  std::map<ref<Expr>, int64_t> right;
   Expr::Kind kind;
   ref<Expr> originalExpr;
+
 public:
-  InequalityExpr(std::map<ref<Expr>, int64_t > left, std::map<ref<Expr>, int64_t > right, Expr::Kind _kind, ref<Expr> originalExpr);
+  InequalityExpr(std::map<ref<Expr>, int64_t> left,
+                 std::map<ref<Expr>, int64_t> right, Expr::Kind _kind,
+                 ref<Expr> originalExpr);
   ~InequalityExpr();
-  std::map<ref<Expr>, int64_t > getLeft();
-  std::map<ref<Expr>, int64_t > getRight();
+  std::map<ref<Expr>, int64_t> getLeft();
+  std::map<ref<Expr>, int64_t> getRight();
   ref<Expr> getOriginalExpr();
   Expr::Kind getKind();
-  void updateLeft(std::map<ref<Expr>, int64_t > newLeft);
-  void updateRight(std::map<ref<Expr>, int64_t > newRight);
+  void updateLeft(std::map<ref<Expr>, int64_t> newLeft);
+  void updateRight(std::map<ref<Expr>, int64_t> newRight);
 };
-
 
 class SubsumptionTableEntry {
   uintptr_t nodeId;
@@ -125,28 +127,44 @@ class SubsumptionTableEntry {
   static ref<Expr> createBinaryOfSameKind(ref<Expr> originalExpr,
                                           ref<Expr> newLhs, ref<Expr> newRhs);
 
-  static ref<Expr> createBinaryExpr( Expr::Kind kind,
-                                          ref<Expr> newLhs, ref<Expr> newRhs);
+  static ref<Expr> createBinaryExpr(Expr::Kind kind, ref<Expr> newLhs,
+                                    ref<Expr> newRhs);
 
   static bool containShadowExpr(ref<Expr> expr, ref<Expr> shadowExpr);
 
-  static std::map<ref<Expr>, int64_t > getCoefficient(ref<Expr> expr);
+  static std::map<ref<Expr>, int64_t> getCoefficient(ref<Expr> expr);
 
-  static std::map<ref<Expr>, int64_t > coefficientOperation(Expr::Kind kind, std::map<ref<Expr>, int64_t > map1, std::map<ref<Expr>, int64_t > map2);
+  static std::map<ref<Expr>, int64_t>
+  coefficientOperation(Expr::Kind kind, std::map<ref<Expr>, int64_t> map1,
+                       std::map<ref<Expr>, int64_t> map2);
 
-  static void normalization(const Array *onFocusExistential, Expr::Kind kind, std::map<ref<Expr>, int64_t > &left, std::map<ref<Expr>, int64_t > &right);
+  static void normalization(const Array *onFocusExistential, Expr::Kind kind,
+                            std::map<ref<Expr>, int64_t> &left,
+                            std::map<ref<Expr>, int64_t> &right,
+                            bool &isOnFocusVarOnLeft);
 
-  static void classification(const Array *onFocusExistential, InequalityExpr * inequalityExpr, std::vector<InequalityExpr *> &lessThanPack, std::vector<InequalityExpr *> &greaterThanPack, std::vector<InequalityExpr *> &nonePack);
+  static void classification(const Array *onFocusExistential,
+                             InequalityExpr *inequalityExpr,
+                             std::vector<InequalityExpr *> &lessThanPack,
+                             std::vector<InequalityExpr *> &greaterThanPack,
+                             std::vector<InequalityExpr *> &nonePack,
+                             bool isOnFocusVarOnLeft);
+
+  static ref<Expr> getReadExprFromConcatExpr(ref<Expr> expr);
 
   static ref<Expr> simplifyConcatExpr(ref<Expr> expr);
 
-  static std::vector<InequalityExpr *> matching(std::vector<InequalityExpr *> lessThanPack, std::vector<InequalityExpr *> greaterThanPack);
+  static std::vector<InequalityExpr *>
+  matching(std::vector<InequalityExpr *> lessThanPack,
+           std::vector<InequalityExpr *> greaterThanPack);
 
-  static void simplifyMatching(std::map<ref<Expr>, int64_t > &left, std::map<ref<Expr>, int64_t > &right);
+  static void simplifyMatching(std::map<ref<Expr>, int64_t> &left,
+                               std::map<ref<Expr>, int64_t> &right);
 
   static ref<Expr> reconstructExpr(std::vector<InequalityExpr *> pack);
 
-  static ref<Expr> replaceExpr(ref<Expr> originalExpr, ref<Expr> replacedExpr, ref<Expr> withExpr);
+  static ref<Expr> replaceExpr(ref<Expr> originalExpr, ref<Expr> replacedExpr,
+                               ref<Expr> withExpr);
 
   static ref<Expr>
   simplifyInterpolantExpr(std::vector<ref<Expr> > &interpolantPack,
@@ -157,13 +175,15 @@ class SubsumptionTableEntry {
 
   static ref<Expr> simplifyWithFourierMotzkin(ref<Expr> existsExpr);
 
-  static void convertExpression(ref<Expr> expr, std::map<ref<Expr>, ref<Expr> > &map);
+  static void convertExpression(ref<Expr> expr,
+                                std::map<ref<Expr>, ref<Expr> > &map);
 
   static ref<Expr> simplifyExistsExpr(ref<Expr> existsExpr);
 
   static ref<Expr> simplifyArithmeticBody(ref<Expr> existsExpr);
 
-  static void normalizeExpr(std::vector<ref <Expr> > equalityPack, std::vector<ref <Expr> > &inequalityPack);
+  static void normalizeExpr(std::vector<ref<Expr> > equalityPack,
+                            std::vector<ref<Expr> > &inequalityPack);
 
   bool empty() {
     return !interpolant.get() && singletonStoreKeys.empty() &&

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -438,7 +438,7 @@ class SubsumptionTableEntry {
   static void simplifyMatching(std::map<ref<Expr>, int64_t> &leftResult,
                                std::map<ref<Expr>, int64_t> &rightResult);
 
-  static ref<Expr> reconstructExpr(std::vector<InequalityExpr *> pack);
+  static ref<Expr> reconstructExpr(std::vector<InequalityExpr *> &pack);
 
   static bool containsNonConstantExpr(std::map<ref<Expr>, int64_t> map);
 

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -403,7 +403,7 @@ class SubsumptionTableEntry {
 
   static bool containShadowExpr(ref<Expr> expr, ref<Expr> shadowExpr);
 
-  static std::map<ref<Expr>, int64_t> getCoefficient(ref<Expr> expr);
+  static std::map<ref<Expr>, int64_t> getLinearTerms(ref<Expr> expr);
 
   static std::map<ref<Expr>, int64_t>
   coefficientOperation(Expr::Kind kind, std::map<ref<Expr>, int64_t> map1,

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -462,10 +462,22 @@ class SubsumptionTableEntry {
   ///        conjuncts.
   /// \return A pair consisting of a list of simplifiable conjuncts and the new
   ///         expression from which the simplifiable conjuncts have been
-  /// removed.
-  ///         Here all equalities have been converted to pairs of inequalities.
+  ///         removed. Here all equalities have been converted to pairs of
+  ///         inequalities.
   static std::pair<std::vector<ref<Expr> >, ref<Expr> >
   getSimplifiableConjunctsForFourierMotzkin(ref<Expr> conjunction);
+
+  /// Tests if the argument is a variable. A variable here is defined to be
+  /// either a symbolic concatenation or a symbolic read. A concatenation in
+  /// KLEE concatenates reads, and hence can be considered to be a symbolic
+  /// read.
+  ///
+  /// \param A KLEE expression.
+  /// \return true if the parameter is either a concatenation or a read,
+  ///         otherwise, return false.
+  static bool isVariable(ref<Expr> expr) {
+    return llvm::isa<ConcatExpr>(expr.get()) || llvm::isa<ReadExpr>(expr.get());
+  }
 
   static ref<Expr> simplifyWithFourierMotzkin(ref<Expr> existsExpr);
 

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -294,9 +294,9 @@ public:
 
   ref<Expr> packInterpolant(std::vector<const Array *> &replacements);
 
-  void dump();
+  void dump() const;
 
-  void print(llvm::raw_ostream &stream);
+  void print(llvm::raw_ostream &stream) const;
 };
 
 class PathConditionMarker {
@@ -324,14 +324,29 @@ public:
   InequalityExpr(std::map<ref<Expr>, int64_t> left,
                  std::map<ref<Expr>, int64_t> right, Expr::Kind _kind,
                  ref<Expr> originalExpr);
+
   ~InequalityExpr();
+
   std::map<ref<Expr>, int64_t> getLeft();
+
   std::map<ref<Expr>, int64_t> getRight();
+
   ref<Expr> getOriginalExpr();
+
   Expr::Kind getKind();
+
   void updateLeft(std::map<ref<Expr>, int64_t> newLeft);
+
   void updateRight(std::map<ref<Expr>, int64_t> newRight);
+
   void updateKind(Expr::Kind newKind);
+
+  void dump() const {
+    this->print(llvm::errs());
+    llvm::errs() << "\n";
+  }
+
+  void print(llvm::raw_ostream &stream) const;
 };
 
 class SubsumptionTableEntry {
@@ -498,13 +513,14 @@ class ITree {
 
   std::map<uintptr_t, std::vector<SubsumptionTableEntry *> > subsumptionTable;
 
-  void printNode(llvm::raw_ostream &stream, ITreeNode *n, std::string edges);
+  void printNode(llvm::raw_ostream &stream, ITreeNode *n,
+                 std::string edges) const;
 
   /// @brief Displays method running time statistics
   static void printTimeStat(llvm::raw_ostream &stream);
 
   /// @brief Displays subsumption table statistics
-  void printTableStat(llvm::raw_ostream &stream);
+  void printTableStat(llvm::raw_ostream &stream) const;
 
 public:
   ITreeNode *root;
@@ -541,9 +557,9 @@ public:
   static void executeOnNode(ITreeNode *node, llvm::Instruction *instr,
                             std::vector<ref<Expr> > &args);
 
-  void print(llvm::raw_ostream &stream);
+  void print(llvm::raw_ostream &stream) const;
 
-  void dump();
+  void dump() const;
 
   /// @brief Outputs interpolation statistics to standard error.
   void dumpInterpolationStat();

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -337,9 +337,6 @@ class Inequality {
                            std::vector<Inequality *> pack2,
                            std::vector<Inequality *> &result);
 
-  static void simplifyMatching(std::map<ref<Expr>, int64_t> &leftResult,
-                               std::map<ref<Expr>, int64_t> &rightResult);
-
   static bool containsNonConstantExpr(std::map<ref<Expr>, int64_t> map);
 
 public:

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -314,13 +314,13 @@ public:
   void setAsMaybeCore();
 };
 
-class InequalityExpr {
+class Inequality {
   std::map<ref<Expr>, int64_t> lhs;
   std::map<ref<Expr>, int64_t> rhs;
   Expr::Kind kind;
 
-  InequalityExpr(Expr::Kind _kind, std::map<ref<Expr>, int64_t> _lhs,
-                 std::map<ref<Expr>, int64_t> _rhs);
+  Inequality(Expr::Kind _kind, std::map<ref<Expr>, int64_t> _lhs,
+             std::map<ref<Expr>, int64_t> _rhs);
 
   void init(Expr::Kind _kind, std::map<ref<Expr>, int64_t> _lhs,
             std::map<ref<Expr>, int64_t> _rhs);
@@ -333,9 +333,9 @@ class InequalityExpr {
 
   static const Array *getArrayFromConcatExpr(ref<Expr> expr);
 
-  static void matchingLoop(Expr::Kind, std::vector<InequalityExpr *> pack1,
-                           std::vector<InequalityExpr *> pack2,
-                           std::vector<InequalityExpr *> &result);
+  static void matchingLoop(Expr::Kind, std::vector<Inequality *> pack1,
+                           std::vector<Inequality *> pack2,
+                           std::vector<Inequality *> &result);
 
   static void simplifyMatching(std::map<ref<Expr>, int64_t> &leftResult,
                                std::map<ref<Expr>, int64_t> &rightResult);
@@ -343,9 +343,9 @@ class InequalityExpr {
   static bool containsNonConstantExpr(std::map<ref<Expr>, int64_t> map);
 
 public:
-  InequalityExpr(ref<Expr> expr);
+  Inequality(ref<Expr> expr);
 
-  ~InequalityExpr();
+  ~Inequality();
 
   bool normalize(const Array *onFocusExistential);
 
@@ -355,11 +355,11 @@ public:
 
   Expr::Kind getKind() const;
 
-  static std::vector<InequalityExpr *>
-  match(std::vector<InequalityExpr *> lessThanPack,
-        std::vector<InequalityExpr *> greaterThanPack,
-        std::vector<InequalityExpr *> strictLessThanPack,
-        std::vector<InequalityExpr *> strictGreaterThanPack);
+  static std::vector<Inequality *>
+  match(std::vector<Inequality *> lessThanPack,
+        std::vector<Inequality *> greaterThanPack,
+        std::vector<Inequality *> strictLessThanPack,
+        std::vector<Inequality *> strictGreaterThanPack);
 
   void dump() const {
     this->print(llvm::errs());
@@ -424,17 +424,17 @@ class SubsumptionTableEntry {
   static bool containShadowExpr(ref<Expr> expr, ref<Expr> shadowExpr);
 
   static void classify(const Array *onFocusExistential,
-                       InequalityExpr *inequalityExpr,
-                       std::vector<InequalityExpr *> &lessThanPack,
-                       std::vector<InequalityExpr *> &greaterThanPack,
-                       std::vector<InequalityExpr *> &nonePack,
-                       std::vector<InequalityExpr *> &strictLessThanPack,
-                       std::vector<InequalityExpr *> &strictGreaterThanPack,
+                       Inequality *inequalityExpr,
+                       std::vector<Inequality *> &lessThanPack,
+                       std::vector<Inequality *> &greaterThanPack,
+                       std::vector<Inequality *> &nonePack,
+                       std::vector<Inequality *> &strictLessThanPack,
+                       std::vector<Inequality *> &strictGreaterThanPack,
                        bool isOnFocusVarOnLeft);
 
   static ref<Expr> simplifyConcatExpr(ref<Expr> expr);
 
-  static ref<Expr> reconstructExpr(std::vector<InequalityExpr *> &pack);
+  static ref<Expr> reconstructExpr(std::vector<Inequality *> &pack);
 
   static ref<Expr> replaceExpr(ref<Expr> originalExpr, ref<Expr> replacedExpr,
                                ref<Expr> withExpr);

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -349,19 +349,11 @@ public:
 
   bool normalize(const Array *onFocusExistential);
 
-  std::map<ref<Expr>, int64_t> getLhs();
+  std::map<ref<Expr>, int64_t> getLhs() const;
 
-  std::map<ref<Expr>, int64_t> getRhs();
+  std::map<ref<Expr>, int64_t> getRhs() const;
 
-  ref<Expr> getOriginalExpr();
-
-  Expr::Kind getKind();
-
-  void replaceLhs(std::map<ref<Expr>, int64_t> newLeft);
-
-  void replaceRhs(std::map<ref<Expr>, int64_t> newRight);
-
-  void replaceKind(Expr::Kind newKind);
+  Expr::Kind getKind() const;
 
   static std::vector<InequalityExpr *>
   match(std::vector<InequalityExpr *> lessThanPack,

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -339,6 +339,20 @@ class Inequality {
 
   static bool containsNonConstantExpr(std::map<ref<Expr>, int64_t> map);
 
+  static void
+  mergeTermToLinearExpression(std::map<ref<Expr>, int64_t> &linearExpr,
+                              ref<Expr> &expr, int64_t coefficient) {
+    if (linearExpr.count(expr) > 0) {
+      // The linear expression already contains the term's variable, add the
+      // term's coefficient with the linear expression term's coefficient.
+      linearExpr[expr] = linearExpr[expr] + coefficient;
+    } else {
+      // The linear expression does not contain the term's variable, add the
+      // term to it.
+      linearExpr[expr] = coefficient;
+    }
+  }
+
 public:
   Inequality(ref<Expr> expr);
 

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -347,6 +347,13 @@ public:
 
   ~Inequality();
 
+  /// Normalize the current inequality by bringing the term with focus
+  /// variable to the lhs and the rest of the expressions to the rhs.
+  ///
+  /// \param The focus variable (a KLEE array).
+  /// \return Success status, where true means that the operation the
+  ///        the procedure successfully brought the term with focus
+  ///        variable to the rhs of the inequality.
   bool normalize(const Array *onFocusExistential);
 
   std::map<ref<Expr>, int64_t> getLhs() const;

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -87,6 +87,23 @@ public:
   void mayIncludeInInterpolant();
 };
 
+class InequalityExpr{
+  std::map<ref<Expr>, int64_t > left;
+  std::map<ref<Expr>, int64_t > right;
+  Expr::Kind kind;
+  ref<Expr> originalExpr;
+public:
+  InequalityExpr(std::map<ref<Expr>, int64_t > left, std::map<ref<Expr>, int64_t > right, Expr::Kind _kind, ref<Expr> originalExpr);
+  ~InequalityExpr();
+  std::map<ref<Expr>, int64_t > getLeft();
+  std::map<ref<Expr>, int64_t > getRight();
+  ref<Expr> getOriginalExpr();
+  Expr::Kind getKind();
+  void updateLeft(std::map<ref<Expr>, int64_t > newLeft);
+  void updateRight(std::map<ref<Expr>, int64_t > newRight);
+};
+
+
 class SubsumptionTableEntry {
   uintptr_t nodeId;
 
@@ -108,7 +125,26 @@ class SubsumptionTableEntry {
   static ref<Expr> createBinaryOfSameKind(ref<Expr> originalExpr,
                                           ref<Expr> newLhs, ref<Expr> newRhs);
 
+  static ref<Expr> createBinaryExpr( Expr::Kind kind,
+                                          ref<Expr> newLhs, ref<Expr> newRhs);
+
   static bool containShadowExpr(ref<Expr> expr, ref<Expr> shadowExpr);
+
+  static std::map<ref<Expr>, int64_t > getCoefficient(ref<Expr> expr);
+
+  static std::map<ref<Expr>, int64_t > coefficientOperation(Expr::Kind kind, std::map<ref<Expr>, int64_t > map1, std::map<ref<Expr>, int64_t > map2);
+
+  static void normalization(const Array *onFocusExistential, Expr::Kind kind, std::map<ref<Expr>, int64_t > &left, std::map<ref<Expr>, int64_t > &right);
+
+  static void classification(const Array *onFocusExistential, InequalityExpr * inequalityExpr, std::vector<InequalityExpr *> &lessThanPack, std::vector<InequalityExpr *> &greaterThanPack, std::vector<InequalityExpr *> &nonePack);
+
+  static ref<Expr> simplifyConcatExpr(ref<Expr> expr);
+
+  static std::vector<InequalityExpr *> matching(std::vector<InequalityExpr *> lessThanPack, std::vector<InequalityExpr *> greaterThanPack);
+
+  static void simplifyMatching(std::map<ref<Expr>, int64_t > &left, std::map<ref<Expr>, int64_t > &right);
+
+  static ref<Expr> reconstructExpr(std::vector<InequalityExpr *> pack);
 
   static ref<Expr> replaceExpr(ref<Expr> originalExpr, ref<Expr> replacedExpr, ref<Expr> withExpr);
 
@@ -121,9 +157,13 @@ class SubsumptionTableEntry {
 
   static ref<Expr> simplifyWithFourierMotzkin(ref<Expr> existsExpr);
 
+  static void convertExpression(ref<Expr> expr, std::map<ref<Expr>, ref<Expr> > &map);
+
   static ref<Expr> simplifyExistsExpr(ref<Expr> existsExpr);
 
   static ref<Expr> simplifyArithmeticBody(ref<Expr> existsExpr);
+
+  static void normalizeExpr(std::vector<ref <Expr> > equalityPack, std::vector<ref <Expr> > &inequalityPack);
 
   bool empty() {
     return !interpolant.get() && singletonStoreKeys.empty() &&

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -318,12 +318,13 @@ class Inequality {
   std::map<ref<Expr>, int64_t> lhs;
   std::map<ref<Expr>, int64_t> rhs;
   Expr::Kind kind;
+  bool eliminated;
 
   Inequality(Expr::Kind _kind, std::map<ref<Expr>, int64_t> _lhs,
              std::map<ref<Expr>, int64_t> _rhs);
 
   void init(Expr::Kind _kind, std::map<ref<Expr>, int64_t> _lhs,
-            std::map<ref<Expr>, int64_t> _rhs);
+            std::map<ref<Expr>, int64_t> _rhs, bool _eliminated);
 
   static std::map<ref<Expr>, int64_t> getLinearTerms(ref<Expr> expr);
 
@@ -353,6 +354,9 @@ class Inequality {
     }
   }
 
+  static void removeEliminated(std::vector<Inequality *> &inequalityList,
+                               std::vector<Inequality *> &result);
+
 public:
   Inequality(ref<Expr> expr);
 
@@ -362,10 +366,20 @@ public:
   /// variable to the lhs and the rest of the expressions to the rhs.
   ///
   /// \param The focus variable (a KLEE array).
-  /// \return Success status, where true means that the operation the
-  ///        the procedure successfully brought the term with focus
-  ///        variable to the rhs of the inequality.
+  /// \return Success status, where true means that the procedure
+  ///         successfully brought the term with focus variable to the
+  //          rhs of the inequality.
   bool normalize(const Array *onFocusExistential);
+
+  /// This operation sets the elimination status bit to true
+  /// indicating that the inequality is eliminated.
+  void setEliminated() { eliminated = true; }
+
+  /// Query the elimination status of this inequality.
+  ///
+  /// \return The status bit on whether this inequality is
+  ///         eliminated or not.
+  bool isEliminated() const { return eliminated; }
 
   std::map<ref<Expr>, int64_t> getLhs() const;
 

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -143,12 +143,15 @@ class SubsumptionTableEntry {
                             std::map<ref<Expr>, int64_t> &right,
                             bool &isOnFocusVarOnLeft);
 
-  static void classification(const Array *onFocusExistential,
-                             InequalityExpr *inequalityExpr,
-                             std::vector<InequalityExpr *> &lessThanPack,
-                             std::vector<InequalityExpr *> &greaterThanPack,
-                             std::vector<InequalityExpr *> &nonePack,
-                             bool isOnFocusVarOnLeft);
+  static void
+  classification(const Array *onFocusExistential,
+                 InequalityExpr *inequalityExpr,
+                 std::vector<InequalityExpr *> &lessThanPack,
+                 std::vector<InequalityExpr *> &greaterThanPack,
+                 std::vector<InequalityExpr *> &nonePack,
+                 std::vector<InequalityExpr *> &strictLessThanPack,
+                 std::vector<InequalityExpr *> &strictGreaterThanPack,
+                 bool isOnFocusVarOnLeft);
 
   static ref<Expr> getReadExprFromConcatExpr(ref<Expr> expr);
 
@@ -156,10 +159,16 @@ class SubsumptionTableEntry {
 
   static std::vector<InequalityExpr *>
   matching(std::vector<InequalityExpr *> lessThanPack,
-           std::vector<InequalityExpr *> greaterThanPack);
+           std::vector<InequalityExpr *> greaterThanPack,
+           std::vector<InequalityExpr *> strictLessThanPack,
+           std::vector<InequalityExpr *> strictGreaterThanPack);
 
-  static void simplifyMatching(std::map<ref<Expr>, int64_t> &left,
-                               std::map<ref<Expr>, int64_t> &right);
+  static void matchingLoop(Expr::Kind, std::vector<InequalityExpr *> pack1,
+                           std::vector<InequalityExpr *> pack2,
+                           std::vector<InequalityExpr *> &result);
+
+  static void simplifyMatching(std::map<ref<Expr>, int64_t> &leftResult,
+                               std::map<ref<Expr>, int64_t> &rightResult);
 
   static ref<Expr> reconstructExpr(std::vector<InequalityExpr *> pack);
 

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -327,19 +327,19 @@ public:
 
   ~InequalityExpr();
 
-  std::map<ref<Expr>, int64_t> getLeft();
+  std::map<ref<Expr>, int64_t> getLhs();
 
-  std::map<ref<Expr>, int64_t> getRight();
+  std::map<ref<Expr>, int64_t> getRhs();
 
   ref<Expr> getOriginalExpr();
 
   Expr::Kind getKind();
 
-  void updateLeft(std::map<ref<Expr>, int64_t> newLeft);
+  void replaceLhs(std::map<ref<Expr>, int64_t> newLeft);
 
-  void updateRight(std::map<ref<Expr>, int64_t> newRight);
+  void replaceRhs(std::map<ref<Expr>, int64_t> newRight);
 
-  void updateKind(Expr::Kind newKind);
+  void replaceKind(Expr::Kind newKind);
 
   void dump() const {
     this->print(llvm::errs());
@@ -409,29 +409,27 @@ class SubsumptionTableEntry {
   coefficientOperation(Expr::Kind kind, std::map<ref<Expr>, int64_t> map1,
                        std::map<ref<Expr>, int64_t> map2);
 
-  static void normalization(const Array *onFocusExistential,
-                            InequalityExpr *inequalityExpr,
-                            bool &isOnFocusVarOnLeft);
+  static bool normalize(const Array *onFocusExistential,
+                        InequalityExpr *inequalityExpr);
 
-  static void
-  classification(const Array *onFocusExistential,
-                 InequalityExpr *inequalityExpr,
-                 std::vector<InequalityExpr *> &lessThanPack,
-                 std::vector<InequalityExpr *> &greaterThanPack,
-                 std::vector<InequalityExpr *> &nonePack,
-                 std::vector<InequalityExpr *> &strictLessThanPack,
-                 std::vector<InequalityExpr *> &strictGreaterThanPack,
-                 bool isOnFocusVarOnLeft);
+  static void classify(const Array *onFocusExistential,
+                       InequalityExpr *inequalityExpr,
+                       std::vector<InequalityExpr *> &lessThanPack,
+                       std::vector<InequalityExpr *> &greaterThanPack,
+                       std::vector<InequalityExpr *> &nonePack,
+                       std::vector<InequalityExpr *> &strictLessThanPack,
+                       std::vector<InequalityExpr *> &strictGreaterThanPack,
+                       bool isOnFocusVarOnLeft);
 
-  static ref<Expr> getReadExprFromConcatExpr(ref<Expr> expr);
+  static const Array *getArrayFromConcatExpr(ref<Expr> expr);
 
   static ref<Expr> simplifyConcatExpr(ref<Expr> expr);
 
   static std::vector<InequalityExpr *>
-  matching(std::vector<InequalityExpr *> lessThanPack,
-           std::vector<InequalityExpr *> greaterThanPack,
-           std::vector<InequalityExpr *> strictLessThanPack,
-           std::vector<InequalityExpr *> strictGreaterThanPack);
+  match(std::vector<InequalityExpr *> lessThanPack,
+        std::vector<InequalityExpr *> greaterThanPack,
+        std::vector<InequalityExpr *> strictLessThanPack,
+        std::vector<InequalityExpr *> strictGreaterThanPack);
 
   static void matchingLoop(Expr::Kind, std::vector<InequalityExpr *> pack1,
                            std::vector<InequalityExpr *> pack2,
@@ -457,6 +455,17 @@ class SubsumptionTableEntry {
   /// whenever it contains constant equalities.
   static ref<Expr> simplifyEqualityExpr(std::vector<ref<Expr> > &equalityPack,
                                         ref<Expr> expr);
+
+  /// Get simplifiable conjuncts from a possible conjunction.
+  ///
+  /// \param conjunction The conjunction from which we extract simplifiable
+  ///        conjuncts.
+  /// \return A pair consisting of a list of simplifiable conjuncts and the new
+  ///         expression from which the simplifiable conjuncts have been
+  /// removed.
+  ///         Here all equalities have been converted to pairs of inequalities.
+  static std::pair<std::vector<ref<Expr> >, ref<Expr> >
+  getSimplifiableConjunctsForFourierMotzkin(ref<Expr> conjunction);
 
   static ref<Expr> simplifyWithFourierMotzkin(ref<Expr> existsExpr);
 

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -359,6 +359,9 @@ class Inequality {
   static void removeEliminated(std::vector<Inequality *> &inequalityList,
                                std::vector<Inequality *> &result);
 
+  static ref<Expr>
+  reconstructLinearExpression(std::map<ref<Expr>, int64_t> linearTerms);
+
 public:
   Inequality(ref<Expr> expr);
 
@@ -398,6 +401,11 @@ public:
         std::vector<Inequality *> strictGreaterThanPack);
 
   static bool containsNonConstantExpr(std::map<ref<Expr>, int64_t> map);
+
+  /// Build KLEE expression from the current inequality
+  ///
+  /// \return The reconstructed expression
+  ref<Expr> reconstructExpr() const;
 
   void dump() const {
     this->print(llvm::errs());
@@ -455,9 +463,6 @@ class SubsumptionTableEntry {
                               ref<Expr> expr);
 
   static bool hasFree(std::vector<const Array *> &existentials, ref<Expr> expr);
-
-  static ref<Expr> createBinaryExpr(Expr::Kind kind, ref<Expr> newLhs,
-                                    ref<Expr> newRhs);
 
   static bool containShadowExpr(ref<Expr> expr, ref<Expr> shadowExpr);
 
@@ -540,6 +545,9 @@ public:
   static bool isVariable(ref<Expr> expr) {
     return llvm::isa<ConcatExpr>(expr.get()) || llvm::isa<ReadExpr>(expr.get());
   }
+
+  static ref<Expr> createBinaryExpr(Expr::Kind kind, ref<Expr> newLhs,
+                                    ref<Expr> newRhs);
 
   void dump() const;
 

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -470,7 +470,7 @@ class SubsumptionTableEntry {
 
   /// @brief Statistics for simplify expression with Fourier execution time in
   /// subsumption check
-  static StatTimer simplifywithFourierTimer;
+  static StatTimer fourierMotzkinSimplifyTimer;
 
   /// @brief Statistics for actual solver call time in subsumption check
   static StatTimer actualSolverCallTimer;

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -315,10 +315,15 @@ public:
 };
 
 class InequalityExpr {
-  std::map<ref<Expr>, int64_t> left;
-  std::map<ref<Expr>, int64_t> right;
+  std::map<ref<Expr>, int64_t> lhs;
+  std::map<ref<Expr>, int64_t> rhs;
   Expr::Kind kind;
-  ref<Expr> originalExpr;
+
+  InequalityExpr(Expr::Kind _kind, std::map<ref<Expr>, int64_t> _lhs,
+                 std::map<ref<Expr>, int64_t> _rhs);
+
+  void init(Expr::Kind _kind, std::map<ref<Expr>, int64_t> _lhs,
+            std::map<ref<Expr>, int64_t> _rhs);
 
   static std::map<ref<Expr>, int64_t> getLinearTerms(ref<Expr> expr);
 
@@ -338,7 +343,7 @@ class InequalityExpr {
   static bool containsNonConstantExpr(std::map<ref<Expr>, int64_t> map);
 
 public:
-  InequalityExpr(ref<Expr> originalExpr);
+  InequalityExpr(ref<Expr> expr);
 
   ~InequalityExpr();
 

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -329,6 +329,7 @@ public:
   Expr::Kind getKind();
   void updateLeft(std::map<ref<Expr>, int64_t> newLeft);
   void updateRight(std::map<ref<Expr>, int64_t> newRight);
+  void updateKind(Expr::Kind newKind);
 };
 
 class SubsumptionTableEntry {
@@ -369,9 +370,8 @@ class SubsumptionTableEntry {
   coefficientOperation(Expr::Kind kind, std::map<ref<Expr>, int64_t> map1,
                        std::map<ref<Expr>, int64_t> map2);
 
-  static void normalization(const Array *onFocusExistential, Expr::Kind kind,
-                            std::map<ref<Expr>, int64_t> &left,
-                            std::map<ref<Expr>, int64_t> &right,
+  static void normalization(const Array *onFocusExistential,
+		  	  	  	  	  	InequalityExpr * inequalityExpr,
                             bool &isOnFocusVarOnLeft);
 
   static void
@@ -403,7 +403,9 @@ class SubsumptionTableEntry {
 
   static ref<Expr> reconstructExpr(std::vector<InequalityExpr *> pack);
 
-   static ref<Expr> replaceExpr(ref<Expr> originalExpr, ref<Expr> replacedExpr,
+  static bool containsNonConstantExpr(std::map<ref<Expr>, int64_t> map);
+
+  static ref<Expr> replaceExpr(ref<Expr> originalExpr, ref<Expr> replacedExpr,
                                ref<Expr> withExpr);
 
   static ref<Expr>


### PR DESCRIPTION
Hi Andrew, I have pushed the implementation of Fourier Motzkin Elimination algorithm. It currently able to make subsumption for all addition_safe example in https://github.com/feliciahalim/klee-examples/tree/master/basic . 

However, there are still limitations in the current version such as it works only for addition and subtraction operation. This version also has not handle strict inequality. I will continue to work on it by enable more operation and also handling strict inequality. 
