### PR TITLE
DEP: Constraint replacement  (no longer continued)

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -908,7 +908,7 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
       // Validity proof succeeded of a query: antecedent -> consequent.
       // We then extract the unsatisfiability core of antecedent and not
       // consequent as the Craig interpolant.
-      txTree->markPathCondition(current, unsatCore);
+      txTree->markPathCondition(current, unsatCore, condition);
     }
 
     return StatePair(&current, 0);
@@ -923,7 +923,7 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
       // Falsity proof succeeded of a query: antecedent -> consequent,
       // which means that antecedent -> not(consequent) is valid. In this
       // case also we extract the unsat core of the proof
-      txTree->markPathCondition(current, unsatCore);
+      txTree->markPathCondition(current, unsatCore, condition);
     }
 
     return StatePair(0, &current);

--- a/lib/Core/TxDependency.h
+++ b/lib/Core/TxDependency.h
@@ -535,10 +535,11 @@ public:
 
   /// \brief Marking the core constraints on the path condition, and all the
   /// relevant values on the dependency graph, given an unsatistiability core.
-  void unsatCoreInterpolation(const std::vector<ref<Expr> > &unsatCore) {
-    pathCondition->unsatCoreInterpolation(unsatCore);
+  void unsatCoreInterpolation(const std::vector<ref<Expr> > &unsatCore,
+			      ref<Expr> replacementConstraint) {
+    pathCondition->unsatCoreInterpolation(unsatCore, replacementConstraint);
   }
-
+  
   /// \brief Interpolation for memory bound violation
   void memoryBoundViolationInterpolation(llvm::Instruction *inst,
                                          ref<Expr> address);

--- a/lib/Core/TxPathCondition.cpp
+++ b/lib/Core/TxPathCondition.cpp
@@ -112,9 +112,12 @@ void TxPathCondition::unsatCoreInterpolation(
       if (currentPC->parent->left == currentPC) {
         currentPC = currentPC->parent;
         currentPC->usedByLeftPath.insert(pcConstraint);
+        pcConstraint->setReplacementConstraint(replacementConstraint);
       } else if (currentPC->parent->right == currentPC) {
         currentPC = currentPC->parent;
-        currentPC->usedByRightPath.insert(pcConstraint->copy());
+        pcConstraint = pcConstraint->copy();
+        currentPC->usedByRightPath.insert(pcConstraint);
+        pcConstraint->setReplacementConstraint(replacementConstraint);
       }
     }
 

--- a/lib/Core/TxPathCondition.cpp
+++ b/lib/Core/TxPathCondition.cpp
@@ -102,9 +102,6 @@ void TxPathCondition::unsatCoreInterpolation(
       std::map<ref<Expr>, ref<TxPCConstraint> >::iterator pcDepthIter =
           pcDepth.find(*(unsatCore.begin()));
 
-      replacementConstraint = EqExpr::create(
-          ConstantExpr::create(0, Expr::Bool), replacementConstraint);
-
       assert(pcDepthIter != pcDepth.end() &&
              "unsat core constraint not found on path condition");
 

--- a/lib/Core/TxPathCondition.cpp
+++ b/lib/Core/TxPathCondition.cpp
@@ -34,13 +34,16 @@ TxPCConstraint::~TxPCConstraint() {}
 ref<Expr>
 TxPCConstraint::packInterpolant(std::set<const Array *> &replacements) {
   ref<Expr> res;
+  ref<Expr> constraintToUse =
+      replacementConstraint.isNull() ? constraint : replacementConstraint;
+
   if (!shadowed) {
 #ifdef ENABLE_Z3
     shadowConstraint =
-        (NoExistential ? constraint : TxShadowArray::getShadowExpression(
-                                          constraint, replacements));
+        (NoExistential ? constraintToUse : TxShadowArray::getShadowExpression(
+                                               constraintToUse, replacements));
 #else
-    shadowConstraint = constraint;
+    shadowConstraint = constraintToUse;
 #endif
     shadowed = true;
     boundVariables.insert(replacements.begin(), replacements.end());

--- a/lib/Core/TxPathCondition.cpp
+++ b/lib/Core/TxPathCondition.cpp
@@ -142,8 +142,12 @@ void TxPathCondition::unsatCoreInterpolation(
                                          constraintSet.end());
       } else if (currentPC->parent->right == currentPC) {
         currentPC = currentPC->parent;
-        currentPC->usedByRightPath.insert(constraintSet.begin(),
-                                          constraintSet.end());
+        for (std::set<ref<TxPCConstraint> >::iterator
+                 it = constraintSet.begin(),
+                 ie = constraintSet.end();
+             it != ie; ++it) {
+          currentPC->usedByRightPath.insert((*it)->copy());
+        }
       }
     }
   }

--- a/lib/Core/TxPathCondition.h
+++ b/lib/Core/TxPathCondition.h
@@ -72,7 +72,8 @@ public:
 
   void setReplacementConstraint(ref<Expr> _replacementConstraint) {
     if (replacementConstraint.isNull()) {
-      replacementConstraint = _replacementConstraint;
+      if (_replacementConstraint != constraint)
+        replacementConstraint = _replacementConstraint;
       return;
     }
     if (replacementConstraint != _replacementConstraint)

--- a/lib/Core/TxPathCondition.h
+++ b/lib/Core/TxPathCondition.h
@@ -31,6 +31,9 @@ private:
   /// \brief KLEE expression
   ref<Expr> constraint;
 
+  /// \brief The replacement, weaker constraint
+  ref<Expr> replacementConstraint;
+
   /// \brief KLEE expression with variables (arrays) replaced by their shadows
   ref<Expr> shadowConstraint;
 
@@ -57,6 +60,15 @@ public:
   ref<Expr> packInterpolant(std::set<const Array *> &replacements);
 
   uint64_t getDepth() const { return depth; }
+
+  ref<TxPCConstraint> copy() {
+    ref<TxPCConstraint> ret(new TxPCConstraint(constraint, condition, depth));
+    ret->replacementConstraint = replacementConstraint;
+    ret->shadowConstraint = shadowConstraint;
+    ret->shadowed = shadowed;
+    ret->boundVariables = boundVariables;
+    return ret;
+  }
 
   int compare(const TxPCConstraint &other) const;
 

--- a/lib/Core/TxPathCondition.h
+++ b/lib/Core/TxPathCondition.h
@@ -127,11 +127,6 @@ public:
   ref<TxPCConstraint> addConstraint(ref<Expr> constraint,
                                     ref<TxStateValue> condition);
 
-  void unsatCoreInterpolation(const std::vector<ref<Expr> > &unsatCore) {
-    ref<Expr> dummyReplacementConstraint;
-    unsatCoreInterpolation(unsatCore, dummyReplacementConstraint);
-  }
-
   void unsatCoreInterpolation(const std::vector<ref<Expr> > &unsatCore,
                               ref<Expr> replacementConstraint);
 

--- a/lib/Core/TxPathCondition.h
+++ b/lib/Core/TxPathCondition.h
@@ -117,7 +117,13 @@ public:
   ref<TxPCConstraint> addConstraint(ref<Expr> constraint,
                                     ref<TxStateValue> condition);
 
-  void unsatCoreInterpolation(const std::vector<ref<Expr> > &unsatCore);
+  void unsatCoreInterpolation(const std::vector<ref<Expr> > &unsatCore) {
+    ref<Expr> dummyReplacementConstraint;
+    unsatCoreInterpolation(unsatCore, dummyReplacementConstraint);
+  }
+
+  void unsatCoreInterpolation(const std::vector<ref<Expr> > &unsatCore,
+                              ref<Expr> replacementConstraint);
 
   ref<Expr>
   packInterpolant(std::set<const Array *> &replacements,

--- a/lib/Core/TxPathCondition.h
+++ b/lib/Core/TxPathCondition.h
@@ -70,6 +70,16 @@ public:
     return ret;
   }
 
+  void setReplacementConstraint(ref<Expr> _replacementConstraint) {
+    if (replacementConstraint.isNull()) {
+      replacementConstraint = _replacementConstraint;
+      return;
+    }
+    if (replacementConstraint != _replacementConstraint)
+      replacementConstraint =
+          AndExpr::create(_replacementConstraint, replacementConstraint);
+  }
+
   int compare(const TxPCConstraint &other) const;
 
   void dump() const;

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -2320,8 +2320,9 @@ uint64_t TxTreeNode::getInstructionsDepth() { return instructionsDepth; }
 void TxTreeNode::incInstructionsDepth() { ++instructionsDepth; }
 
 void
-TxTreeNode::unsatCoreInterpolation(const std::vector<ref<Expr> > &unsatCore) {
-  dependency->unsatCoreInterpolation(unsatCore);
+TxTreeNode::unsatCoreInterpolation(const std::vector<ref<Expr> > &unsatCore,
+                                   ref<Expr> replacementConstraint) {
+  dependency->unsatCoreInterpolation(unsatCore, replacementConstraint);
 }
 
 void TxTreeNode::dump() const {

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -2077,7 +2077,8 @@ TxTree::split(TxTreeNode *parent, ExecutionState *left, ExecutionState *right) {
 }
 
 void TxTree::markPathCondition(ExecutionState &state,
-                               std::vector<ref<Expr> > &unsatCore) {
+                               std::vector<ref<Expr> > &unsatCore,
+                               ref<Expr> replacementConstraint) {
   TimerStatIncrementer t(markPathConditionTime);
   int debugSubsumptionLevel =
       currentTxTreeNode->dependency->debugSubsumptionLevel;
@@ -2107,7 +2108,7 @@ void TxTree::markPathCondition(ExecutionState &state,
   }
 
   // We create path condition marking structure and mark core constraints
-  currentTxTreeNode->unsatCoreInterpolation(unsatCore);
+  currentTxTreeNode->unsatCoreInterpolation(unsatCore, replacementConstraint);
 }
 
 void TxTree::executePHI(llvm::Instruction *instr, unsigned incomingBlock,

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -749,7 +749,8 @@ public:
   /// \brief Mark the path condition in the Tracer-X tree node associated with
   /// the given KLEE execution state.
   void markPathCondition(ExecutionState &state,
-                         std::vector<ref<Expr> > &unsatCore);
+                         std::vector<ref<Expr> > &unsatCore,
+                         ref<Expr> replacementConstraint);
 
   /// \brief Creates fresh interpolation data holder for the two given KLEE
   /// execution states.

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -518,7 +518,15 @@ public:
 
   /// \brief Marking the core constraints on the path condition, and all the
   /// relevant values on the dependency graph, given an unsatistiability core.
-  void unsatCoreInterpolation(const std::vector<ref<Expr> > &unsatCore);
+  void unsatCoreInterpolation(const std::vector<ref<Expr> > &unsatCore,
+                              ref<Expr> replacementConstraint);
+
+  /// \brief Marking the core constraints on the path condition, and all the
+  /// relevant values on the dependency graph, given an unsatistiability core.
+  void unsatCoreInterpolation(const std::vector<ref<Expr> > &unsatCore) {
+    ref<Expr> dummyReplacementConstraint;
+    unsatCoreInterpolation(unsatCore, dummyReplacementConstraint);
+  }
 
   /// \brief Memory bounds interpolation from a target address. Returns true if
   /// memory bounds check fails somehow.


### PR DESCRIPTION
This replaces unsat core constraints on the path condition with a more general one. Basically, if `c1,...,cN => d`, with the only unsat core is `cI`, we replace `cI` with `d` in the interpolant. #191 is a related problem. Currently:
1. It does not work with `Regexp.c` and all examples in `basic`: Investigation is needed.
2. PCConstraint::copy() calls can probably be avoided by having left/right replacement constraint instead, so that memory usage becomes more efficient.

**Not ready to be merged.**