### PR TITLE
fix(subsumption): missed candidate basic blocks

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1471,6 +1471,7 @@ Executor::StatePair Executor::branchFork(ExecutionState &current,
     }
 
     if (INTERPOLATION_ENABLED) {
+      current.txTreeNode = txTree->splitSingle(current.txTreeNode, &current);
       // Validity proof succeeded of a query: antecedent -> consequent.
       // We then extract the unsatisfiability core of antecedent and not
       // consequent as the Craig interpolant.
@@ -1585,6 +1586,7 @@ Executor::StatePair Executor::branchFork(ExecutionState &current,
     }
 
     if (INTERPOLATION_ENABLED) {
+      current.txTreeNode = txTree->splitSingle(current.txTreeNode, &current);
       // Falsity proof succeeded of a query: antecedent -> consequent,
       // which means that antecedent -> not(consequent) is valid. In this
       // case also we extract the unsat core of the proof
@@ -3021,6 +3023,9 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
     if (INTERPOLATION_ENABLED)
       txTree->setPhiValuesFlag(0);
     if (bi->isUnconditional()) {
+      if(INTERPOLATION_ENABLED) {
+        state.txTreeNode = txTree->splitSingle(state.txTreeNode, &state);
+      }
       transferToBasicBlock(bi->getSuccessor(0), bi->getParent(), state);
       if (INTERPOLATION_ENABLED)
         txTree->execute(i);

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -2433,6 +2433,14 @@ void TxTree::remove(ExecutionState *state, TimingSolver *solver, bool dumping) {
 #endif
 }
 
+TxTreeNode * TxTree::splitSingle(TxTreeNode *parent, ExecutionState *newState) {
+  TimerStatIncrementer t(splitTime);
+  TxTreeNode *const ret = parent->createChild<&TxTreeNode::left>();
+  newState->txTreeNode = ret;
+  TxTreeGraph::addChildren(parent, parent->left, parent->left);
+  return ret;
+}
+
 std::pair<TxTreeNode *, TxTreeNode *>
 TxTree::split(TxTreeNode *parent, ExecutionState *left, ExecutionState *right) {
   TimerStatIncrementer t(splitTime);
@@ -2993,8 +3001,8 @@ void TxTreeNode::addConstraint(ref<Expr> &constraint, llvm::Value *condition) {
 void TxTreeNode::split(ExecutionState *leftData, ExecutionState *rightData) {
   TimerStatIncrementer t(splitTime);
   assert(left == 0 && right == 0);
-  leftData->txTreeNode = createLeftChild();
-  rightData->txTreeNode = createRightChild();
+  leftData->txTreeNode = createChild<&TxTreeNode::left>();
+  rightData->txTreeNode = createChild<&TxTreeNode::right>();
   if (INTERPOLATION_ENABLED && SpecTypeToUse != NO_SPEC &&
       this->speculationFlag) {
     leftData->txTreeNode->setSpeculationFlag();


### PR DESCRIPTION
This fixes a lot of candidate basic blocks incorrectly ignored for subsumption. Some fixing required for this patch and will be done after initial benchmarking.