### PR TITLE
WP propagate to support bb-unmerge

### DIFF
--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -2795,6 +2795,9 @@ ref<Expr> TxTreeNode::generateWPInterpolant() {
       llvm::BranchInst *br = dyn_cast<llvm::BranchInst>(i);
       if (br->isConditional()) {
         branchCondition = wp->getBrCondition(i);
+      } else {
+        // Branch is unconditional, this implies branch conditional of true
+        branchCondition = wp->True();
       }
     }
     if (!branchCondition.isNull()) {


### PR DESCRIPTION
Before this PR, when TX is run with bb-unmerge and WP, TX will soon fallback to deletion due to lack of support this PR adds.