### PR TITLE
fix(TxTreeGraph): outputs accurate graph on bb-unmerge

### DIFF
--- a/include/klee/util/TxTreeGraph.h
+++ b/include/klee/util/TxTreeGraph.h
@@ -174,6 +174,8 @@ public:
     instance = 0;
   }
 
+  static void addChildren(TxTreeNode *parent, TxTreeNode *theOnlyChild);
+
   static void addChildren(TxTreeNode *parent, TxTreeNode *falseChild,
                           TxTreeNode *trueChild);
 

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -2477,7 +2477,7 @@ TxTreeNode * TxTree::splitSingle(TxTreeNode *parent, ExecutionState *newState) {
   TimerStatIncrementer t(splitTime);
   TxTreeNode *const ret = parent->createChild<&TxTreeNode::left>();
   newState->txTreeNode = ret;
-  TxTreeGraph::addChildren(parent, parent->left, parent->left);
+  TxTreeGraph::addChildren(parent, parent->left);
   return ret;
 }
 

--- a/lib/Core/TxTreeGraph.cpp
+++ b/lib/Core/TxTreeGraph.cpp
@@ -150,8 +150,11 @@ std::string TxTreeGraph::recurseRender(TxTreeGraph::Node *node) {
       stream << "(terminal #" << it->second << ")\\l";
     }
   }
-  if (node->falseTarget || node->trueTarget)
+  if (node->falseTarget && node->trueTarget) {
     stream << "|{<s0>F|<s1>T}";
+  } else if(node->falseTarget || node->trueTarget) {
+    stream << "|{<s0>Single Child}";
+  }
   stream << "}\"];\n";
 
   if (node->falseTarget) {
@@ -266,6 +269,25 @@ TxTreeGraph::~TxTreeGraph() {
   leaves.clear();
 
   leafToLeafSequenceNumber.clear();
+}
+
+void TxTreeGraph::addChildren(TxTreeNode *const parent, TxTreeNode *const theOnlyChild) {
+  nodeCount += 1;
+
+  if (!OUTPUT_INTERPOLATION_TREE)
+    return;
+
+  assert(TxTreeGraph::instance && "Search tree graph not initialized");
+
+  TxTreeGraph::Node *parentNode = instance->txTreeNodeMap[parent];
+
+  parentNode->falseTarget =
+      TxTreeGraph::Node::createNode(parentNode->markCount);
+  parentNode->falseTarget->parent = parentNode;
+  instance->txTreeNodeMap[theOnlyChild] = parentNode->falseTarget;
+
+  instance->leaves.erase(parentNode);
+  instance->leaves.insert(parentNode->falseTarget);
 }
 
 void TxTreeGraph::addChildren(TxTreeNode *parent, TxTreeNode *falseChild,


### PR DESCRIPTION
Before this PR, tree graphs with bb-unmerge enable have lots of unvisted nodes. This fixes it.