### PR TITLE
feat: tx node tags

### DIFF
--- a/include/klee/klee.h
+++ b/include/klee/klee.h
@@ -181,6 +181,9 @@ extern "C" {
   /* Check if a vector of integers is stored previously. */
   void tracerx_memo_check();
 
+  /* add msg to node as label, followed by optional subsequent arguments to be added as well */
+  void tracerx_node_tag(const char *msg, ...);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/klee/util/TxTreeGraph.h
+++ b/include/klee/util/TxTreeGraph.h
@@ -65,6 +65,8 @@ private:
     /// \brief Indicates that node is subsumed
     bool subsumed;
 
+    std::vector<std::string> nodeTags;
+
     /// \brief Conditions under which this node is visited from its parent
     std::map<TxPCConstraint *, std::pair<std::string, bool> >
     pathConditionTable;
@@ -182,6 +184,8 @@ public:
 
   static void markAsSubsumed(TxTreeNode *txTreeNode,
                              TxSubsumptionTableEntry *entry);
+
+  static void updateNodeTags(TxTreeNode *txTreeNode, const std::vector<std::string> &nodeTags);
 
   static void addPathCondition(TxTreeNode *txTreeNode,
                                TxPCConstraint *pathCondition,

--- a/lib/Core/SpecialFunctionHandler.cpp
+++ b/lib/Core/SpecialFunctionHandler.cpp
@@ -141,6 +141,7 @@ static SpecialFunctionHandler::HandlerInfo handlerInfo[] = {
     add("tracerx_debug_state_off", handleDebugStateOff, false),
     add("tracerx_memo_check", handleMemoCheck, true),
     add("tracerx_memo", handleMemo, false),
+    add("tracerx_node_tag", handleTxNodeTag, false),
 #undef addDNR
 #undef add
 };
@@ -733,6 +734,22 @@ void SpecialFunctionHandler::handleMemo(ExecutionState &state,
   }
 
   po.insert(obj);
+}
+
+void SpecialFunctionHandler::handleTxNodeTag(
+    ExecutionState &state, KInstruction *target,
+    std::vector<ref<Expr> > &arguments) {
+  assert(!arguments.empty() &&
+         "invalid number of arguments to tracerx_node_tag");
+
+  if(!INTERPOLATION_ENABLED) {
+    return;
+  }
+
+  std::string msg_str = readStringAtAddress(state, arguments[0]);
+  std::stringstream ss;
+  std::for_each(std::next(arguments.cbegin()), arguments.cend(), [&ss](const auto &x) { ss << x; });
+  state.txTreeNode->addNodeTagToParent(msg_str + ss.str());
 }
 
 void SpecialFunctionHandler::handleGetValue(

--- a/lib/Core/SpecialFunctionHandler.h
+++ b/lib/Core/SpecialFunctionHandler.h
@@ -125,6 +125,7 @@ namespace klee {
     HANDLER(handleDebugSubsumptionOff);
     HANDLER(handleMemoCheck);
     HANDLER(handleMemo);
+    HANDLER(handleTxNodeTag);
     HANDLER(handleDefineFixedObject);
     HANDLER(handleDelete);    
     HANDLER(handleDeleteArray);

--- a/lib/Core/TxTree.cpp
+++ b/lib/Core/TxTree.cpp
@@ -30,6 +30,7 @@
 #include <klee/util/TxExprUtil.h>
 #include <klee/util/TxPrintUtil.h>
 #include <vector>
+#include <numeric>
 
 #if LLVM_VERSION_CODE >= LLVM_VERSION(3, 5)
 #include <llvm/IR/DebugInfo.h>
@@ -52,7 +53,10 @@ Statistic TxSubsumptionTableEntry::solverAccessTime("solverAccessTime",
 TxSubsumptionTableEntry::TxSubsumptionTableEntry(
     TxTreeNode *node, const std::vector<llvm::Instruction *> &callHistory)
     : programPoint(node->getProgramPoint()),      
-      nodeSequenceNumber(node->getNodeSequenceNumber()),CfileLineNumber(node->getCfileLineNumber()),CfileName(node->getCfileName()),CFuntionName(node->getCFunctionName()) {
+      nodeSequenceNumber(node->getNodeSequenceNumber()),
+      CfileLineNumber(node->getCfileLineNumber()),CfileName(node->getCfileName()),CFuntionName(node->getCFunctionName()),
+      nodeTags(node->nodeTags)
+{
   std::map<ref<Expr>, ref<Expr> > substitution;
   existentials.clear();
   interpolant = node->getInterpolant(existentials, substitution);
@@ -1823,6 +1827,13 @@ void TxSubsumptionTableEntry::print(llvm::raw_ostream &stream,
   stream << prefix << "------------ Subsumption Table Entry ------------\n";
   stream << prefix << "Program point = " << programPoint << "\n"; 
   stream << prefix << "C-File Name:Function Name:Line number = " << CfileName << ":"<<CFuntionName<<":" <<CfileLineNumber <<"\n";
+  if(!nodeTags.empty()) {
+    stream << prefix << "Node Tags: ";
+    stream << std::accumulate(std::next(nodeTags.cbegin()), nodeTags.cend(), nodeTags[0],
+      [](const auto &x, const auto &y) { return x + ',' + y; }
+    );
+    stream << '\n';
+  }
   if (MarkGlobal) {
     stream << prefix << "global = [";
     for (std::set<ref<TxStoreEntry> >::iterator it = markedGlobal.begin(),

--- a/lib/Core/TxTree.h
+++ b/lib/Core/TxTree.h
@@ -323,6 +323,8 @@ public:
 
    std::string CFuntionName;
 
+  std::vector<std::string> nodeTags;
+
 
   TxSubsumptionTableEntry(TxTreeNode *node,
                           const std::vector<llvm::Instruction *> &callHistory);
@@ -421,6 +423,7 @@ public:
 /// \see TxSubsumptionTableEntry
 class TxTreeNode {
   friend class TxTree;
+  friend class TxSubsumptionTableEntry;
 
   friend class ExecutionState;
 
@@ -468,6 +471,9 @@ class TxTreeNode {
   TxTreeNode *parent, *left, *right;
 
   uintptr_t programPoint;
+
+  // Label for human consumption
+  std::vector<std::string> nodeTags;
 
   llvm::BasicBlock *basicBlock;
 
@@ -637,6 +643,11 @@ public:
 
   /// \brief Returning the right node
   TxTreeNode *getRight() { return right; }
+
+  void addNodeTagToParent(const std::string &s) {
+    nodeTags.push_back(s);
+    TxTreeGraph::updateNodeTags(this, nodeTags);
+  }
   
   template<TxTreeNode* TxTreeNode::* const childAttr>
   TxTreeNode *createChild() {

--- a/lib/Core/TxTreeGraph.cpp
+++ b/lib/Core/TxTreeGraph.cpp
@@ -36,6 +36,7 @@
 
 #include <fstream>
 #include <string>
+#include <numeric>
 
 using namespace klee;
 
@@ -117,6 +118,15 @@ std::string TxTreeGraph::recurseRender(TxTreeGraph::Node *node) {
       stream << " ITP";
     stream << "\\l";
   }
+
+  const auto &nodeTags = node->nodeTags;
+  if(!nodeTags.empty()) {
+    stream << std::accumulate(std::next(nodeTags.cbegin()), nodeTags.cend(), nodeTags[0],
+      [](const auto &x, const auto &y) { return x + ',' + y; }
+    );
+    stream << "\\l";
+  }
+
   if (node->markCount) {
     stream << "mark(s): " << node->markCount;
     if (node->markAddition) {
@@ -345,6 +355,18 @@ void TxTreeGraph::markAsSubsumed(TxTreeNode *txTreeNode,
   TxTreeGraph::Node *subsuming = instance->tableEntryMap[entry];
   instance->subsumptionEdges.push_back(new TxTreeGraph::NumberedEdge(
       node, subsuming, ++(instance->subsumptionEdgeNumber)));
+}
+
+void TxTreeGraph::updateNodeTags(TxTreeNode *txTreeNode, const std::vector<std::string> &nodeTags) {
+  if (!OUTPUT_INTERPOLATION_TREE)
+    return;
+
+  assert(TxTreeGraph::instance && "Search tree graph not initialized");
+
+  TxTreeGraph::Node *node = instance->txTreeNodeMap[txTreeNode];
+
+  // TODO: optimize this to avoid copying
+  node->nodeTags = nodeTags;
 }
 
 void TxTreeGraph::addPathCondition(TxTreeNode *txTreeNode,

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -920,11 +920,12 @@ static const char *modelledExternals[] = {
   "__ubsan_handle_mul_overflow",
   "__ubsan_handle_divrem_overflow",
   "tracerx_debug_subsumption",
-  "tracerx_debug_subsumption_off"
+  "tracerx_debug_subsumption_off",
   "tracerx_debug_state",
-  "tracerx_debug_state_off"
-  "tracerx_memo"
-  "tracerx_memo_check"
+  "tracerx_debug_state_off",
+  "tracerx_memo",
+  "tracerx_memo_check",
+  "tracerx_node_tag"
 };
 // Symbols we aren't going to warn about
 static const char *dontCareExternals[] = {


### PR DESCRIPTION
When study tx subsumption tables, it's important to understand the state the node is for. This PR adds new function `tracerx_node_tag` to allow user program to add tags to the TxTreeNode which are displayed in both debug-subsumption and the tree grpah. This should greatly improve our understanding and debugging process.

One usage example is `tracerx_node_tag("i=", i)` where i is the looping var. With this, it's easy to understand which iteration the TxTreeNode is for.